### PR TITLE
feat: build initial responsive landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# FuzzFolio-Landing
-Landing wireframe / semi functional to eventually launch
+# FuzzFolio Landing
+
+Static landing page for the FuzzFolio SaaS MVP. The page is built with plain HTML, CSS and a bit of JavaScript.
+
+## Development
+
+Open `index.html` in your browser to view the site.

--- a/index.html
+++ b/index.html
@@ -2,22 +2,84 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>FuzzFolio</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <header>
-    <h1>Welcome to FuzzFolio</h1>
+  <header class="header">
+    <div class="container">
+      <div class="logo">FuzzFolio</div>
+      <nav class="nav" id="nav-menu">
+        <a href="#features">Features</a>
+        <a href="#how">How It Works</a>
+        <a href="#contact">Contact</a>
+        <a href="#" class="cta">Join Waitlist</a>
+      </nav>
+      <button class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
   </header>
-  <main>
-    <p>Your next favorite portfolio is coming soon.</p>
-  </main>
-  <footer>
-    <p>&copy; <span id="year"></span> FuzzFolio</p>
+
+  <section class="hero">
+    <div class="container">
+      <h1>Let the market come to you</h1>
+      <p>Build fuzzy scoring profiles and get alerted only when opportunity knocks.</p>
+      <a href="#" class="btn">Join the waitlist</a>
+    </div>
+  </section>
+
+  <section id="features" class="features">
+    <div class="container">
+      <h2>Features</h2>
+      <div class="feature-grid">
+        <div class="feature">
+          <h3>Create profiles</h3>
+          <p>Mix and match indicators into reusable fuzzy scoring profiles.</p>
+        </div>
+        <div class="feature">
+          <h3>Attach to instruments</h3>
+          <p>Apply profiles to the assets you care about most.</p>
+        </div>
+        <div class="feature">
+          <h3>Backtest & refine</h3>
+          <p>See how your ideas would have played out across history.</p>
+        </div>
+        <div class="feature">
+          <h3>Real-time alerts</h3>
+          <p>Activate profiles and get notified of fresh opportunities.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="how" class="how">
+    <div class="container">
+      <h2>How It Works</h2>
+      <ol class="steps">
+        <li>Craft a fuzzy scoring profile with your favorite indicators.</li>
+        <li>Attach it to trading instruments and backtest the results.</li>
+        <li>Set it live and let FuzzFolio watch the charts for you.</li>
+      </ol>
+    </div>
+  </section>
+
+  <section id="contact" class="cta-section">
+    <div class="container">
+      <h2>Ready to trade smarter?</h2>
+      <p>Join the waitlist and be first to know when we launch.</p>
+      <a href="#" class="btn">Join the waitlist</a>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="container">
+      <p>&copy; <span id="year"></span> FuzzFolio</p>
+    </div>
   </footer>
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
+
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,9 @@
+const yearEl = document.getElementById('year');
+yearEl.textContent = new Date().getFullYear();
+
+const navToggle = document.getElementById('nav-toggle');
+const navMenu = document.getElementById('nav-menu');
+
+navToggle.addEventListener('click', () => {
+  navMenu.classList.toggle('open');
+});

--- a/styles.css
+++ b/styles.css
@@ -1,16 +1,181 @@
+:root {
+  --color-bg: #f7f7f9;
+  --color-text: #1d1d1f;
+  --color-accent: #6a5acd;
+  --color-accent-light: #8e7bff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-  font-family: Arial, sans-serif;
   margin: 0;
-  padding: 0;
-  text-align: center;
-  background-color: #f5f5f5;
-  color: #333;
+  font-family: 'Inter', Arial, sans-serif;
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
 }
-header, footer {
-  background-color: #222;
+
+a {
+  color: inherit;
+}
+
+.container {
+  width: 90%;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.header {
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.header .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.5rem;
+}
+
+.nav {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.nav a {
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.nav a.cta {
+  background: var(--color-accent);
   color: #fff;
-  padding: 1rem;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
 }
-main {
-  padding: 2rem;
+
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.nav-toggle span {
+  width: 25px;
+  height: 2px;
+  background: var(--color-text);
+}
+
+@media (max-width: 768px) {
+  .nav {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    background: #fff;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+  }
+
+  .nav.open {
+    max-height: 300px;
+    padding: 1rem 0;
+  }
+
+  .nav-toggle {
+    display: flex;
+  }
+}
+
+.hero {
+  background: linear-gradient(135deg, #f0f0f3, #dcdde8);
+  text-align: center;
+  padding: 8rem 0 6rem;
+}
+
+.hero h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  max-width: 600px;
+  margin: 0.5rem auto 2rem;
+}
+
+.btn {
+  display: inline-block;
+  background: var(--color-accent);
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: 600;
+  transition: opacity 0.2s;
+}
+
+.btn:hover {
+  opacity: 0.9;
+}
+
+.features {
+  background: #fff;
+  padding: 5rem 0;
+}
+
+.features h2 {
+  text-align: center;
+}
+
+.feature-grid {
+  margin-top: 2rem;
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.feature {
+  background: var(--color-bg);
+  padding: 1.5rem;
+  border-radius: 8px;
+  text-align: left;
+}
+
+.how {
+  padding: 5rem 0;
+  text-align: center;
+}
+
+.how .steps {
+  margin-top: 2rem;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: left;
+}
+
+.cta-section {
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-light));
+  color: #fff;
+  text-align: center;
+  padding: 5rem 0;
+}
+
+.footer {
+  background: #fff;
+  text-align: center;
+  padding: 2rem 0;
+  font-size: 0.875rem;
 }


### PR DESCRIPTION
## Summary
- Add responsive landing page with hero, feature overview, and call-to-action sections.
- Implement mobile navigation toggle and dynamic footer year.
- Style using subtle gradients and monochrome palette with accent color.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b329a27dac8325b110d22263dc3cdd