### PR TITLE
Add backtesting feature content to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       <div class="logo">FuzzFolio</div>
       <nav class="nav" id="nav-menu">
         <a href="#features">Features</a>
+        <a href="#backtesting">Backtesting</a>
         <a href="#benefits">Benefits</a>
         <a href="#how">How It Works</a>
         <a href="#contact" class="cta">Join Waitlist</a>
@@ -55,6 +56,21 @@
           <p>Your dashboard keeps watching whether markets are open or closed—no more missed signals.</p>
         </div>
       </div>
+    </div>
+  </section>
+
+  <section id="backtesting" class="backtesting">
+    <div class="container">
+      <h2>Backtesting with FuzzFolio</h2>
+      <p>FuzzFolio’s built‑in backtester lets you pressure‑test any trading profile before it ever touches a live chart.</p>
+      <ul class="benefit-list">
+        <li><strong>Historical fidelity</strong> — Pull up to 5,000 bars of clean OHLC data for any supported pair and timeframe, then run the exact fuzzy‑logic scoring engine used in real time to see how your signals would have performed.</li>
+        <li><strong>Rapid iteration</strong> — Adjust indicator weights or add new pairs, hit “Run Backtest,” and instantly overlay long/short scores on a synchronized candlestick chart. Spot weak links or confirm edge without exporting to spreadsheets.</li>
+        <li><strong>Batch insights</strong> — Kick off multiple instrument/profile combinations in one request to compare setups side‑by‑side and uncover which markets or configurations deserve your attention.</li>
+        <li><strong>Full transparency</strong> — Every score comes back with the underlying price action and timestamped indicator values, so you can trace “why” as easily as “what.”</li>
+        <li><strong>Weekend‑proof workflow</strong> — Because FuzzFolio’s data layer simulates off‑market ticks, you can keep refining strategies even when the exchanges are closed.</li>
+      </ul>
+      <p>With FuzzFolio, backtesting is no longer a separate app or a pile of CSVs—it’s a seamless extension of the same dashboard you’ll use in production, giving you fast, visual feedback on every idea.</p>
     </div>
   </section>
 

--- a/styles.css
+++ b/styles.css
@@ -176,13 +176,15 @@ a {
 }
 
 .benefits,
-.problems {
+.problems,
+.backtesting {
   background: var(--color-bg);
   padding: 5rem 0;
 }
 
 .benefits h2,
-.problems h2 {
+.problems h2,
+.backtesting h2 {
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- Add backtesting section with detailed feature copy
- Link navigation to new backtesting section
- Style backtesting section to match other landing page sections

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b36b575c0883258e54dbefd629feb0