### PR TITLE
Obfuscate data source and streamline backtesting section

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@
 
   <section class="hero">
     <div class="container">
-      <h1>Your Real‑Time Forex Advantage</h1>
-      <p>FuzzFolio turns a constant stream of MT4 data into clean, actionable insight so you can react the moment opportunity appears.</p>
+        <h1>Your Real‑Time Forex Advantage</h1>
+        <p>FuzzFolio turns a constant stream of premium market data into clean, actionable insight so you can react the moment opportunity appears.</p>
       <a href="#" class="btn">Join the waitlist</a>
     </div>
   </section>
@@ -40,7 +40,7 @@
       <h2>What FuzzFolio gives you</h2>
       <div class="feature-grid">
         <div class="feature">
-          <h3>Live market feed from MT4</h3>
+          <h3>Live market feed from a premium source</h3>
           <p>Every pair updates automatically with 5‑minute and hourly bars, plus key indicators like RSI and moving averages. Simulated weekends keep your strategies sharp.</p>
         </div>
         <div class="feature">
@@ -61,16 +61,14 @@
 
   <section id="backtesting" class="backtesting">
     <div class="container">
-      <h2>Backtesting with FuzzFolio</h2>
-      <p>FuzzFolio’s built‑in backtester lets you pressure‑test any trading profile before it ever touches a live chart.</p>
+      <h2>Backtesting built in</h2>
+      <p>Vet any trading profile with the same fuzzy‑logic engine that powers live alerts.</p>
       <ul class="benefit-list">
-        <li><strong>Historical fidelity</strong> — Pull up to 5,000 bars of clean OHLC data for any supported pair and timeframe, then run the exact fuzzy‑logic scoring engine used in real time to see how your signals would have performed.</li>
-        <li><strong>Rapid iteration</strong> — Adjust indicator weights or add new pairs, hit “Run Backtest,” and instantly overlay long/short scores on a synchronized candlestick chart. Spot weak links or confirm edge without exporting to spreadsheets.</li>
-        <li><strong>Batch insights</strong> — Kick off multiple instrument/profile combinations in one request to compare setups side‑by‑side and uncover which markets or configurations deserve your attention.</li>
-        <li><strong>Full transparency</strong> — Every score comes back with the underlying price action and timestamped indicator values, so you can trace “why” as easily as “what.”</li>
-        <li><strong>Weekend‑proof workflow</strong> — Because FuzzFolio’s data layer simulates off‑market ticks, you can keep refining strategies even when the exchanges are closed.</li>
+        <li><strong>Clean history</strong> for up to 5,000 bars per pair and timeframe.</li>
+        <li><strong>Fast iteration</strong> on indicator weights and pair selections.</li>
+        <li><strong>Traceable outcomes</strong> with price and indicator context.</li>
       </ul>
-      <p>With FuzzFolio, backtesting is no longer a separate app or a pile of CSVs—it’s a seamless extension of the same dashboard you’ll use in production, giving you fast, visual feedback on every idea.</p>
+      <p>Backtesting is woven into the workflow so refining strategies takes seconds.</p>
     </div>
   </section>
 
@@ -79,7 +77,7 @@
       <h2>Why traders love it</h2>
       <ul class="benefit-list">
         <li><strong>Clarity over noise</strong> — Scores are weighted by your own rules, so only high‑probability setups rise to the top.</li>
-        <li><strong>Less platform juggling</strong> — Replace multiple MT4 windows with one streamlined workspace, responsive on large monitors and tablets.</li>
+        <li><strong>Less platform juggling</strong> — Replace multiple trading terminals with one streamlined workspace, responsive on large monitors and tablets.</li>
         <li><strong>Transparency you can trust</strong> — Every score links back to its indicators so you know why a pair looks bullish or bearish.</li>
         <li><strong>Built for speed</strong> — Sub‑second refreshes mean you're working with the most current data, not yesterday's close.</li>
       </ul>


### PR DESCRIPTION
## Summary
- Generalize market data references to a premium real-time source
- Trim backtesting content to keep it balanced with other features
- Update benefits text to avoid naming specific trading platforms

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b38cdf6b4c83258f8c0b4e99ed8fa2