### PR TITLE
Revise landing page copy and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,9 @@
         <a href="#backtesting">Backtesting</a>
         <a href="#benefits">Benefits</a>
         <a href="#how">How It Works</a>
-        <a href="#contact" class="cta">Join Waitlist</a>
+        <a href="#plans">Plans</a>
+        <a href="#faq">FAQ</a>
+        <a href="#contact" class="cta">Join Free Setup Radar</a>
       </nav>
       <div class="actions">
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">🌓</button>
@@ -29,9 +31,10 @@
 
   <section class="hero fade-in">
     <div class="container">
-        <h1>Your Real‑Time Forex Advantage</h1>
-        <p>FuzzFolio turns a constant stream of premium market data into clean, actionable insight so you can react the moment opportunity appears.</p>
-      <a href="#" class="btn">Join the waitlist</a>
+        <h1>Trade calmer. Decide faster.</h1>
+        <p>Real-time setup radar and rule-based signals—built for transparency, not hype.</p>
+      <a href="#" class="btn">Join Free Setup Radar</a>
+      <a href="#" class="btn secondary">Become a Founding Member</a>
     </div>
   </section>
 
@@ -40,20 +43,20 @@
       <h2>What FuzzFolio gives you</h2>
       <div class="feature-grid">
         <div class="feature fade-in">
-          <h3>Live market feed from a premium source</h3>
-          <p>Every pair updates automatically with 5‑minute and hourly bars, plus key indicators like RSI and moving averages. Simulated weekends keep your strategies sharp.</p>
+          <h3>Live market view (fast refresh)</h3>
+          <p>See clean 5-minute and hourly views with core indicators (e.g., RSI, MAs). Data refreshes quickly (typically every 15–30 seconds) so you’re working with current context, not yesterday’s close.</p>
         </div>
         <div class="feature fade-in">
           <h3>Instant opportunity scores</h3>
-          <p>Multiple indicators roll up into a single <span class="bullish">long</span>/<span class="bearish">short</span> score so setups stand out immediately.</p>
+          <p>Fuzzy logic rolls multiple indicators into a single <span class="bullish">long</span>/<span class="bearish">short</span> score—so probable setups stand out immediately.</p>
         </div>
         <div class="feature fade-in">
           <h3>Everything at a glance</h3>
-          <p>A tile‑based overview shows trend lines, scores and status for every pair. Side panels let you dive into full charts when you're ready.</p>
+          <p>A tile overview shows status for each pair. Click any tile to open the full chart and indicator breakdown.</p>
         </div>
         <div class="feature fade-in">
-          <h3>Always‑on monitoring</h3>
-          <p>Your dashboard keeps watching whether markets are open or closed—no more missed signals.</p>
+          <h3>Alerts that meet you where you are</h3>
+          <p>Get real-time alerts via the web app (PWA) and, for paid members, Telegram.</p>
         </div>
       </div>
     </div>
@@ -62,35 +65,34 @@
   <section id="backtesting" class="backtesting fade-in">
     <div class="container">
       <h2>Backtesting built in</h2>
-      <p>Vet any trading profile with the same fuzzy‑logic engine that powers live alerts.</p>
+      <p>Validate a scoring profile with the same engine that powers live alerts.</p>
       <ul class="benefit-list">
-        <li class="fade-in"><strong>Clean history</strong> for up to 5,000 bars per pair and timeframe.</li>
-        <li class="fade-in"><strong>Fast iteration</strong> on indicator weights and pair selections.</li>
-        <li class="fade-in"><strong>Traceable outcomes</strong> with price and indicator context.</li>
+        <li class="fade-in"><strong>Configurable lookbacks</strong> (e.g., up to ~5,000 bars per pair/timeframe)</li>
+        <li class="fade-in"><strong>Fast iteration</strong> on indicator weights and pair selection</li>
+        <li class="fade-in"><strong>Traceable outcomes</strong> with price + indicator context</li>
       </ul>
-      <p>Backtesting is woven into the workflow so refining strategies takes seconds.</p>
     </div>
   </section>
 
   <section id="benefits" class="benefits fade-in">
     <div class="container">
-      <h2>Why traders love it</h2>
+      <h2>Why traders choose FuzzFolio</h2>
       <ul class="benefit-list">
-        <li class="fade-in"><strong>Clarity over noise</strong> — Scores are weighted by your own rules, so only high‑probability setups rise to the top.</li>
-        <li class="fade-in"><strong>Less platform juggling</strong> — Replace multiple trading terminals with one streamlined workspace, responsive on large monitors and tablets.</li>
-        <li class="fade-in"><strong>Transparency you can trust</strong> — Every score links back to its indicators so you know why a pair looks bullish or bearish.</li>
-        <li class="fade-in"><strong>Built for speed</strong> — Sub‑second refreshes mean you're working with the most current data, not yesterday's close.</li>
+        <li class="fade-in"><strong>Clarity over noise</strong> — Rule-based scores highlight only the cleanest setups.</li>
+        <li class="fade-in"><strong>Less platform juggling</strong> — One streamlined workspace (desktop + tablet friendly).</li>
+        <li class="fade-in"><strong>Transparency you can trust</strong> — Every signal links back to its indicators and is logged with outcomes—wins and losses.</li>
+        <li class="fade-in"><strong>Built for speed</strong> — Fast refresh and instant alerts keep your timing sharp.</li>
       </ul>
     </div>
   </section>
 
   <section id="problems" class="problems fade-in">
     <div class="container">
-      <h2>Problems it solves</h2>
+      <h2>Designed to fix</h2>
       <ul class="problem-list">
-        <li class="fade-in">Overwhelming chart hopping</li>
-        <li class="fade-in">Inconsistent decision logic</li>
-        <li class="fade-in">Weekend downtime</li>
+        <li class="fade-in">Overwhelming chart-hopping</li>
+        <li class="fade-in">Inconsistent decision rules</li>
+        <li class="fade-in">Missed opportunities without alerts</li>
         <li class="fade-in">Manual data wrangling</li>
       </ul>
     </div>
@@ -100,24 +102,104 @@
     <div class="container">
       <h2>How it works</h2>
       <ol class="steps">
-        <li class="fade-in">Create a fuzzy scoring profile with your favourite indicators.</li>
-        <li class="fade-in">Attach it to the pairs you track and backtest the results.</li>
-        <li class="fade-in">Set it live and let FuzzFolio alert you to fresh opportunities.</li>
+        <li class="fade-in">Create a scoring profile with your preferred indicators.</li>
+        <li class="fade-in">Backtest across the pairs and timeframes you trade.</li>
+        <li class="fade-in">Go live: receive alerts and see each signal’s full context and rules.</li>
       </ol>
+    </div>
+  </section>
+
+  <section id="plans" class="features fade-in">
+    <div class="container">
+      <h2>Plans</h2>
+      <div class="feature-grid">
+        <div class="feature fade-in">
+          <h3>Free — Setup Radar</h3>
+          <ul>
+            <li>2–3 curated watchlist opportunities per week (no entries)</li>
+            <li>Weekly recap</li>
+            <li>Great for evaluating the approach</li>
+          </ul>
+        </div>
+        <div class="feature fade-in">
+          <h3>Founding Member — Signals + Stats</h3>
+          <ul>
+            <li>Precise entries, SL/TP, and management notes</li>
+            <li>Live results log with CSV export (R-multiples, win rate, drawdown)</li>
+            <li>Alerts in the app + private Telegram</li>
+            <li>Founders price lock (first 150 seats), cancel anytime</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="sample" class="features fade-in">
+    <div class="container">
+      <h2>Sample signal</h2>
+      <div class="feature fade-in">
+        <p><strong>[Signal] EURUSD LONG (H1)</strong><br>
+        Entry 1.0912 · SL 1.0884 · TP1 1.0958 · TP2 1.0990<br>
+        R:R 1.6 (TP1), 2.8 (TP2) · Risk/unit: 0.5–1.0%<br>
+        Why: Pullback into 50% + 200MA confluence; momentum confirmation<br>
+        Management: Move SL to BE at 1.0945; partial at TP1<br>
+        Outcome: Posted automatically to results log</p>
+      </div>
+    </div>
+  </section>
+
+  <section id="transparency" class="benefits fade-in">
+    <div class="container">
+      <h2>Transparency & trust</h2>
+      <ul class="benefit-list">
+        <li class="fade-in"><strong>Methodology in plain English</strong> Exactly which indicators are considered, how scores are computed, and how risk is sized.</li>
+        <li class="fade-in"><strong>Public results policy</strong> We post every outcome—winners and losers. You can export CSVs and audit any signal back to its inputs.</li>
+        <li class="fade-in"><strong>No-hype promise</strong> No DMs. No account management. Cancel anytime.</li>
+      </ul>
+    </div>
+  </section>
+
+  <section id="faq" class="features fade-in">
+    <div class="container">
+      <h2>FAQ</h2>
+      <div class="feature-grid">
+        <div class="feature fade-in">
+          <h3>Is this financial advice?</h3>
+          <p>No. FuzzFolio provides educational analysis and rule-based alerts only.</p>
+        </div>
+        <div class="feature fade-in">
+          <h3>How often are alerts?</h3>
+          <p>We only publish when a setup meets our rules. Frequency varies by market conditions.</p>
+        </div>
+        <div class="feature fade-in">
+          <h3>What’s the refresh rate?</h3>
+          <p>The live view updates quickly (typically every 15–30 seconds).</p>
+        </div>
+        <div class="feature fade-in">
+          <h3>What if I’m new?</h3>
+          <p>Start with Free Setup Radar to learn the structure and cadence before subscribing.</p>
+        </div>
+        <div class="feature fade-in">
+          <h3>Founders price—what does that mean?</h3>
+          <p>Early members get a permanent price lock and early access to new features. Limited seats keep support and signal quality high.</p>
+        </div>
+      </div>
     </div>
   </section>
 
   <section id="contact" class="cta-section fade-in">
     <div class="container">
-      <h2>Stay in the loop</h2>
-      <p>Join the waitlist and be the first to trade with FuzzFolio.</p>
-      <a href="#" class="btn">Join the waitlist</a>
+      <h2>Start trading smarter</h2>
+      <p>Join Free Setup Radar for teaser insights or become a Founding Member for full signals and stats.</p>
+      <a href="#" class="btn">Join Free Setup Radar</a>
+      <a href="#" class="btn secondary">Become a Founding Member</a>
     </div>
   </section>
 
   <footer class="footer">
     <div class="container">
       <p>&copy; <span id="year"></span> FuzzFolio</p>
+      <p class="disclaimer">FuzzFolio provides educational market analysis and rule-based alerts. It is not financial advice. Trading involves risk. Past performance does not guarantee future results. We publish wins and losses and recommend using strict position sizing.</p>
     </div>
   </footer>
 

--- a/styles.css
+++ b/styles.css
@@ -178,6 +178,23 @@ a {
   transform: translateY(-2px);
 }
 
+.btn.secondary {
+  background: transparent;
+  border: 2px solid var(--color-accent);
+  color: var(--color-accent);
+}
+
+.btn.secondary:hover {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.disclaimer {
+  margin-top: 1rem;
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
 .features {
   background: var(--color-bg);
   padding: 5rem 0;


### PR DESCRIPTION
## Summary
- Update hero and features with accurate, less hypey language and add CTA options.
- Introduce plans, sample signal, transparency & FAQ sections plus disclaimer footer.
- Add secondary button styling and footer disclaimer styles.

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4876783488325924ad6082286bd07