### PR TITLE
Revamp landing page messaging and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,6 @@
       <div class="logo">FuzzFolio</div>
       <nav class="nav" id="nav-menu">
         <a href="#features">Features</a>
-        <a href="#backtesting">Backtesting</a>
-        <a href="#benefits">Benefits</a>
         <a href="#how">How It Works</a>
         <a href="#plans">Plans</a>
         <a href="#faq">FAQ</a>
@@ -32,23 +30,24 @@
   <section class="hero fade-in">
     <div class="container">
         <h1>Trade calmer. Decide faster.</h1>
-        <p>Real-time setup radar and rule-based signals—built for transparency, not hype.</p>
+        <p>Real-time setup radar to focus your attention on moments that matter.</p>
       <a href="#" class="btn">Join Free Setup Radar</a>
-      <a href="#" class="btn secondary">Become a Founding Member</a>
+      <a href="#" class="btn secondary">Become an Early Access Member</a>
     </div>
   </section>
 
   <section id="features" class="features fade-in">
     <div class="container">
       <h2>What FuzzFolio gives you</h2>
+      <img src="https://via.placeholder.com/800x400?text=Dashboard+Preview" alt="FuzzFolio dashboard preview" class="dashboard-preview">
       <div class="feature-grid">
         <div class="feature fade-in">
           <h3>Live market view (fast refresh)</h3>
           <p>See clean 5-minute and hourly views with core indicators (e.g., RSI, MAs). Data refreshes quickly (typically every 15–30 seconds) so you’re working with current context, not yesterday’s close.</p>
         </div>
         <div class="feature fade-in">
-          <h3>Instant opportunity scores</h3>
-          <p>Fuzzy logic rolls multiple indicators into a single <span class="bullish">long</span>/<span class="bearish">short</span> score—so probable setups stand out immediately.</p>
+          <h3>Real-time scoring alerts</h3>
+          <p>Fuzzy logic rolls multiple indicators into a single <span class="bullish">long</span>/<span class="bearish">short</span> probability with context so you can act quickly.</p>
         </div>
         <div class="feature fade-in">
           <h3>Everything at a glance</h3>
@@ -57,6 +56,10 @@
         <div class="feature fade-in">
           <h3>Alerts that meet you where you are</h3>
           <p>Get real-time alerts via the web app (PWA) and, for paid members, Telegram.</p>
+        </div>
+        <div class="feature fade-in">
+          <h3>Historical performance log</h3>
+          <p>Review past setups and export CSVs to validate your own strategies.</p>
         </div>
       </div>
     </div>
@@ -80,7 +83,7 @@
       <ul class="benefit-list">
         <li class="fade-in"><strong>Clarity over noise</strong> — Rule-based scores highlight only the cleanest setups.</li>
         <li class="fade-in"><strong>Less platform juggling</strong> — One streamlined workspace (desktop + tablet friendly).</li>
-        <li class="fade-in"><strong>Transparency you can trust</strong> — Every signal links back to its indicators and is logged with outcomes—wins and losses.</li>
+        <li class="fade-in"><strong>Transparency you can trust</strong> — Every alert links back to its indicators and is logged with outcomes—wins and losses.</li>
         <li class="fade-in"><strong>Built for speed</strong> — Fast refresh and instant alerts keep your timing sharp.</li>
       </ul>
     </div>
@@ -104,7 +107,7 @@
       <ol class="steps">
         <li class="fade-in">Create a scoring profile with your preferred indicators.</li>
         <li class="fade-in">Backtest across the pairs and timeframes you trade.</li>
-        <li class="fade-in">Go live: receive alerts and see each signal’s full context and rules.</li>
+        <li class="fade-in">Go live: receive alerts and see each setup’s full context and rules.</li>
       </ol>
     </div>
   </section>
@@ -116,18 +119,18 @@
         <div class="feature fade-in">
           <h3>Free — Setup Radar</h3>
           <ul>
-            <li>2–3 curated watchlist opportunities per week (no entries)</li>
+            <li>Curated watchlist opportunities (2–3 per week)</li>
             <li>Weekly recap</li>
             <li>Great for evaluating the approach</li>
           </ul>
         </div>
         <div class="feature fade-in">
-          <h3>Founding Member — Signals + Stats</h3>
+          <h3>Early Access Member — Full Feed</h3>
           <ul>
-            <li>Precise entries, SL/TP, and management notes</li>
-            <li>Live results log with CSV export (R-multiples, win rate, drawdown)</li>
-            <li>Alerts in the app + private Telegram</li>
-            <li>Founders price lock (first 150 seats), cancel anytime</li>
+            <li>Real-time scoring alerts with context</li>
+            <li>Historical performance log with CSV export</li>
+            <li>Deep-dive analysis via PWA and private Telegram</li>
+            <li>Price lock for early members (first 150 seats), cancel anytime</li>
           </ul>
         </div>
       </div>
@@ -136,14 +139,11 @@
 
   <section id="sample" class="features fade-in">
     <div class="container">
-      <h2>Sample signal</h2>
+      <h2>Sample setup</h2>
       <div class="feature fade-in">
-        <p><strong>[Signal] EURUSD LONG (H1)</strong><br>
-        Entry 1.0912 · SL 1.0884 · TP1 1.0958 · TP2 1.0990<br>
-        R:R 1.6 (TP1), 2.8 (TP2) · Risk/unit: 0.5–1.0%<br>
-        Why: Pullback into 50% + 200MA confluence; momentum confirmation<br>
-        Management: Move SL to BE at 1.0945; partial at TP1<br>
-        Outcome: Posted automatically to results log</p>
+        <p><strong>[Setup] EURUSD H1 — 78% long probability</strong><br>
+        Rationale: Pullback into 50% + 200MA confluence with momentum confirmation.<br>
+        The score is posted to the feed with full indicator breakdown so you can decide how to trade.</p>
       </div>
     </div>
   </section>
@@ -153,8 +153,17 @@
       <h2>Transparency & trust</h2>
       <ul class="benefit-list">
         <li class="fade-in"><strong>Methodology in plain English</strong> Exactly which indicators are considered, how scores are computed, and how risk is sized.</li>
-        <li class="fade-in"><strong>Public results policy</strong> We post every outcome—winners and losers. You can export CSVs and audit any signal back to its inputs.</li>
+        <li class="fade-in"><strong>Public results policy</strong> We post every outcome—winners and losers. You can export CSVs and audit any setup back to its inputs.</li>
         <li class="fade-in"><strong>No-hype promise</strong> No DMs. No account management. Cancel anytime.</li>
+      </ul>
+    </div>
+  </section>
+
+  <section id="social-proof" class="benefits fade-in">
+    <div class="container">
+      <h2>Traders say</h2>
+      <ul class="benefit-list">
+        <li class="fade-in"><strong>"FuzzFolio focuses my attention on the best setups so I'm not glued to charts all day."</strong> — Beta user</li>
       </ul>
     </div>
   </section>
@@ -180,8 +189,8 @@
           <p>Start with Free Setup Radar to learn the structure and cadence before subscribing.</p>
         </div>
         <div class="feature fade-in">
-          <h3>Founders price—what does that mean?</h3>
-          <p>Early members get a permanent price lock and early access to new features. Limited seats keep support and signal quality high.</p>
+          <h3>Early access price—what does that mean?</h3>
+          <p>Early members get a permanent price lock and early access to new features. Limited seats keep support and alert quality high.</p>
         </div>
       </div>
     </div>
@@ -190,9 +199,9 @@
   <section id="contact" class="cta-section fade-in">
     <div class="container">
       <h2>Start trading smarter</h2>
-      <p>Join Free Setup Radar for teaser insights or become a Founding Member for full signals and stats.</p>
+      <p>Join Free Setup Radar for teaser insights or become an Early Access Member for full scoring feed and dashboards.</p>
       <a href="#" class="btn">Join Free Setup Radar</a>
-      <a href="#" class="btn secondary">Become a Founding Member</a>
+      <a href="#" class="btn secondary">Become an Early Access Member</a>
     </div>
   </section>
 

--- a/styles.css
+++ b/styles.css
@@ -166,10 +166,11 @@ a {
   display: inline-block;
   background: linear-gradient(135deg, var(--color-accent), var(--color-accent-light));
   color: #fff;
-  padding: 0.75rem 1.5rem;
-  border-radius: 4px;
+  padding: 1rem 2rem;
+  border-radius: 6px;
   text-decoration: none;
   font-weight: 600;
+  font-size: 1rem;
   transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
@@ -211,9 +212,17 @@ a {
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 }
 
+.dashboard-preview {
+  width: 100%;
+  max-width: 800px;
+  display: block;
+  margin: 2rem auto;
+  border-radius: 8px;
+}
+
 .feature {
-  background: linear-gradient(135deg, var(--color-surface), #262626);
-  padding: 1.5rem;
+  background: #2a2a2a;
+  padding: 2rem;
   border-radius: 8px;
   text-align: left;
   transition: transform 0.3s ease, box-shadow 0.3s ease;
@@ -249,8 +258,8 @@ a {
 
 .benefit-list li,
 .problem-list li {
-  background: linear-gradient(135deg, var(--color-surface), #262626);
-  padding: 1rem 1.25rem;
+  background: #2a2a2a;
+  padding: 1.25rem 1.5rem;
   border-radius: 8px;
   margin-bottom: 1rem;
   transition: transform 0.3s ease, box-shadow 0.3s ease;
@@ -274,7 +283,7 @@ a {
 }
 
 .how {
-  background: var(--color-bg);
+  background: var(--color-surface);
   padding: 5rem 0;
   text-align: center;
 }
@@ -285,6 +294,13 @@ a {
   margin-left: auto;
   margin-right: auto;
   text-align: left;
+}
+
+.how .steps li {
+  background: #2a2a2a;
+  padding: 1rem 1.25rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
 }
 
 .cta-section {


### PR DESCRIPTION
## Summary
- Reframed hero, plan, and CTA copy to emphasize trader empowerment over signals.
- Simplified navigation, added dashboard preview image, testimonial, and sample setup card.
- Improved contrast and legibility with larger buttons, lighter card backgrounds, and clearer "How it works" steps.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b48c614bac83259858e6130b3e51b6