### PR TITLE
Revamp hero section with interactive preview cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
   <header class="header">
     <div class="container">
-      <div class="logo">FuzzFolio</div>
+      <div class="logo"><span class="brand-icon">F</span></div>
       <nav class="nav" id="nav-menu">
         <a href="#features">Features</a>
         <a href="#how">How It Works</a>
@@ -29,10 +29,30 @@
 
   <section class="hero fade-in">
     <div class="container">
-        <h1>Trade calmer. Decide faster.</h1>
-        <p>Real-time setup radar to focus your attention on moments that matter.</p>
-      <a href="#" class="btn">Join Free Setup Radar</a>
-      <a href="#" class="btn secondary">Become an Early Access Member</a>
+      <div class="hero-content">
+        <h1>See clean setups. Trade on your terms.</h1>
+        <p>FuzzFolio helps you identify optimal trading setups with AI-powered analysis, giving you the edge you need to make informed decisions and maximize your returns.</p>
+        <a href="#" class="btn">Join Free Setup Radar</a>
+        <a href="#" class="btn secondary">Sample a setup</a>
+        <p class="trust">Trusted by 5,000+ traders globally</p>
+      </div>
+      <div class="hero-cards">
+        <div class="signal-card card1" tabindex="0">
+          <h4>Setup Radar</h4>
+          <p class="score">85/100</p>
+          <p class="meta">Strong momentum, bullish</p>
+        </div>
+        <div class="signal-card card2" tabindex="0">
+          <h4>Setup Radar</h4>
+          <p class="score">78/100</p>
+          <p class="meta">Low volume, watchlist</p>
+        </div>
+        <div class="signal-card card3" tabindex="0">
+          <h4>Setup Radar</h4>
+          <p class="score">73/100</p>
+          <p class="meta">Higher timeframe alignment</p>
+        </div>
+      </div>
     </div>
   </section>
 

--- a/script.js
+++ b/script.js
@@ -26,3 +26,12 @@ const observer = new IntersectionObserver(
 );
 
 document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
+
+// Interactive hero cards
+const cards = document.querySelectorAll('.signal-card');
+cards.forEach(card => {
+  card.addEventListener('click', () => {
+    cards.forEach(c => c.classList.remove('active'));
+    card.classList.add('active');
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -51,6 +51,17 @@ a {
   font-size: 1.5rem;
 }
 
+.brand-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: var(--color-accent);
+  color: #fff;
+  border-radius: 4px;
+}
+
 .nav {
   display: flex;
   gap: 1.5rem;
@@ -147,9 +158,22 @@ a {
 }
 
 .hero {
-  background: linear-gradient(135deg, #1e1e1e, #2a2a2a);
-  text-align: center;
+  background: radial-gradient(circle at 20% 20%, rgba(106, 90, 205, 0.4), transparent 60%),
+    linear-gradient(135deg, #1e1e1e, #2a2a2a);
   padding: 8rem 0 6rem;
+}
+
+.hero .container {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.hero-content {
+  flex: 1 1 300px;
+  text-align: left;
+  max-width: 500px;
 }
 
 .hero h1 {
@@ -159,7 +183,70 @@ a {
 
 .hero p {
   max-width: 600px;
-  margin: 0.5rem auto 2rem;
+  margin: 0.5rem 0 2rem;
+}
+
+.trust {
+  font-size: 0.875rem;
+  opacity: 0.8;
+  margin-top: 1rem;
+}
+
+.hero-cards {
+  flex: 1 1 300px;
+  position: relative;
+  height: 260px;
+  margin-top: 2rem;
+}
+
+.signal-card {
+  position: absolute;
+  width: 140px;
+  height: 200px;
+  padding: 1rem;
+  background: var(--color-surface);
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+  cursor: pointer;
+}
+
+.signal-card h4 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.signal-card .score {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0 0 0.25rem;
+}
+
+.signal-card .meta {
+  font-size: 0.875rem;
+  opacity: 0.8;
+  margin: 0;
+}
+
+.card1 {
+  transform: rotate(-15deg) translate(-60px, 20px);
+}
+
+.card2 {
+  transform: rotate(5deg) translate(0, 0);
+}
+
+.card3 {
+  transform: rotate(15deg) translate(60px, 20px);
+}
+
+.signal-card:hover,
+.signal-card:focus,
+.signal-card.active {
+  transform: scale(1.1) translate(0, -20px) rotate(0deg);
+  z-index: 10;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.5);
+  outline: none;
 }
 
 .btn {


### PR DESCRIPTION
## Summary
- Replace text logo with square "F" icon
- Rework hero section copy and add three interactive signal preview cards
- Apply new gradient background and hover/tap animations

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b4a2f499548325b356d64780e4257e