### PR TITLE
Enhance header and hero cards

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,11 +29,27 @@ const observer = new IntersectionObserver(
 
 document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
 
-// Interactive hero cards
-const cards = document.querySelectorAll('.signal-card');
-cards.forEach(card => {
-  card.addEventListener('click', () => {
-    cards.forEach(c => c.classList.remove('active'));
-    card.classList.add('active');
-  });
+// Highlight nav links on scroll
+const sections = document.querySelectorAll('section[id]');
+const navLinks = document.querySelectorAll('.nav a[href^="#"]');
+
+const sectionObserver = new IntersectionObserver(
+  entries => {
+    entries.forEach(entry => {
+      const id = entry.target.getAttribute('id');
+      const link = document.querySelector(`.nav a[href="#${id}"]`);
+      if (entry.isIntersecting) {
+        navLinks.forEach(l => l.classList.remove('active'));
+        if (link) link.classList.add('active');
+      }
+    });
+  },
+  { rootMargin: '-50% 0px -50% 0px' }
+);
+
+sections.forEach(section => sectionObserver.observe(section));
+
+// Prevent hero cards from staying shifted when clicked
+document.querySelectorAll('.signal-card').forEach(card => {
+  card.addEventListener('click', () => card.blur());
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -37,8 +37,13 @@ a {
 }
 
 .header {
-  background: linear-gradient(90deg, var(--color-surface), #242424);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: radial-gradient(circle at 40px 50%, rgba(106, 90, 205, 0.35), transparent 70%),
+    linear-gradient(135deg, #1e1e1e, #2a2a2a);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(8px);
 }
 
 .header .container {
@@ -101,6 +106,16 @@ a {
   padding: 0.5rem 1rem;
   border-radius: 4px;
   transition: transform 0.2s ease;
+}
+
+.nav a.active {
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-light));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.nav a.active::after {
+  width: 100%;
 }
 
 .nav a.cta:hover {
@@ -209,8 +224,12 @@ a {
   background: var(--color-surface);
   border-radius: 12px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  transition: transform 0.4s ease, box-shadow 0.4s ease;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
   cursor: pointer;
+  --rotate: 0deg;
+  --tx: 0px;
+  --ty: 0px;
+  transform: rotate(var(--rotate)) translate(var(--tx), var(--ty));
 }
 
 .signal-card h4 {
@@ -230,24 +249,31 @@ a {
   margin: 0;
 }
 
+
 .card1 {
-  transform: rotate(-15deg) translate(-60px, 20px);
+  --rotate: -10deg;
+  --tx: -80px;
+  --ty: 20px;
 }
 
 .card2 {
-  transform: rotate(5deg) translate(0, 0);
+  --rotate: 0deg;
+  --tx: 0px;
+  --ty: 0px;
 }
 
 .card3 {
-  transform: rotate(15deg) translate(60px, 20px);
+  --rotate: 10deg;
+  --tx: 80px;
+  --ty: 20px;
 }
 
+
 .signal-card:hover,
-.signal-card:focus,
-.signal-card.active {
-  transform: scale(1.1) translate(0, -20px) rotate(0deg);
+.signal-card:focus {
+  transform: rotate(var(--rotate)) translate(var(--tx), calc(var(--ty) - 5px));
   z-index: 10;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
   outline: none;
 }
 


### PR DESCRIPTION
## Summary
- Add radial gradient and sticky positioning to header, with active link highlighting on scroll
- Reduce hero card overlap and simplify hover effect to a slight upward shift

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4b6c571448325b2c9e24d91ad9e73