### PR TITLE
Make header share background gradient

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -6,12 +6,16 @@
   --color-text: #f5f5f5;
   --color-accent: #6a5acd;
   --color-accent-light: #8e7bff;
+  --gradient-bg: radial-gradient(circle at 20% 20%, rgba(106, 90, 205, 0.4), transparent 60%),
+    linear-gradient(135deg, #1e1e1e, #2a2a2a);
 }
 
 body.light {
   --color-bg: #f5f5f5;
   --color-surface: #ffffff;
   --color-text: #1e1e1e;
+  --gradient-bg: radial-gradient(circle at 20% 20%, rgba(142, 123, 255, 0.4), transparent 60%),
+    linear-gradient(135deg, #f5f5f5, #ffffff);
 }
 
 * {
@@ -21,7 +25,7 @@ body.light {
 body {
   margin: 0;
   font-family: 'Inter', Arial, sans-serif;
-  background: var(--color-bg);
+  background: var(--gradient-bg);
   color: var(--color-text);
   line-height: 1.6;
 }
@@ -40,8 +44,7 @@ a {
   position: sticky;
   top: 0;
   z-index: 50;
-  background: radial-gradient(circle at 40px 50%, rgba(106, 90, 205, 0.35), transparent 70%),
-    linear-gradient(135deg, #1e1e1e, #2a2a2a);
+  background: transparent;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(8px);
 }
@@ -175,8 +178,6 @@ a {
 }
 
 .hero {
-  background: radial-gradient(circle at 20% 20%, rgba(106, 90, 205, 0.4), transparent 60%),
-    linear-gradient(135deg, #1e1e1e, #2a2a2a);
   padding: 8rem 0 6rem;
 }
 


### PR DESCRIPTION
## Summary
- Move gradient background to the page root and let header inherit it
- Keep header sticky while allowing gradient to show through

## Testing
- `npm run build`
```
vite v7.1.3 building for production...
transforming...
✓ 4 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                 10.36 kB │ gzip: 3.22 kB
dist/assets/index-DpSw5XE-.css   9.92 kB │ gzip: 2.95 kB
dist/assets/index-BUI72EZp.js    1.75 kB │ gzip: 0.78 kB
✓ built in 298ms
```


------
https://chatgpt.com/codex/tasks/task_e_68b4c6f3055083259e388d8b42413e24