### PR TITLE
feat: add polished placeholder landing components

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,12 @@
 </head>
 <body class="font-[Inter] bg-slate-950 text-white">
   <header class="sticky top-0 z-50 bg-slate-900/80 backdrop-blur">
-    <nav class="max-w-7xl mx-auto flex items-center justify-between p-4">
+    <nav class="max-w-7xl mx-auto flex items-center justify-between p-4 relative">
       <div class="font-bold text-xl">FuzzFolio</div>
-      <div class="hidden md:flex gap-6 items-center" id="nav-menu">
+      <button id="mobile-toggle" class="md:hidden" aria-label="Toggle navigation">
+        <span class="text-2xl">☰</span>
+      </button>
+      <div id="nav-menu" class="hidden flex-col gap-4 absolute top-full left-0 w-full bg-slate-900/90 p-4 md:static md:flex md:flex-row md:gap-6 md:w-auto md:bg-transparent md:p-0 items-center">
         <a href="#features" class="hover:text-purple-400">Features</a>
         <a href="#plans" class="hover:text-purple-400">Plans</a>
         <a href="#faq" class="hover:text-purple-400">FAQ</a>

--- a/src/components/backtestingSection.js
+++ b/src/components/backtestingSection.js
@@ -13,7 +13,10 @@ export default function BacktestingSection() {
           <li>Traceable outcomes with price context</li>
         </ul>
       </div>
-      <div class="aspect-video bg-gray-700 rounded"></div>
+      <div>
+        <div class="aspect-[16/9] skeleton" role="img" aria-label="Backtest chart mockup"><span class="skeleton-label">16:9</span></div>
+        <p class="mt-2 text-xs text-gray-400">Backtest chart mockup (16:9)</p>
+      </div>
     </div>
   `;
   return section;

--- a/src/components/ctaSection.js
+++ b/src/components/ctaSection.js
@@ -8,6 +8,7 @@ export default function CTASection() {
       <a href="#" class="btn-primary">Join Free Setup Radar</a>
       <a href="#" class="btn-secondary">Become an Early Access Member</a>
     </div>
+    <p class="mt-4 text-sm text-white/80">No credit card required.</p>
   `;
   return section;
 }

--- a/src/components/faqAccordion.js
+++ b/src/components/faqAccordion.js
@@ -7,18 +7,18 @@ export default function FAQAccordion() {
       <h2 class="section-title">FAQ</h2>
       <div class="space-y-4">
         <div class="border border-gray-700 rounded">
-          <button class="w-full text-left px-4 py-3 flex justify-between items-center faq-question">
+          <button class="w-full text-left px-4 py-3 flex justify-between items-center faq-question" aria-expanded="false" aria-controls="faq1">
             <span>Is this financial advice?</span>
-            <span class="text-xl">+</span>
+            <span class="toggle-icon text-xl">+</span>
           </button>
-          <div class="px-4 pb-4 hidden faq-answer">No. FuzzFolio provides educational analysis...</div>
+          <div id="faq1" class="px-4 pb-4 hidden faq-answer" aria-hidden="true">No. FuzzFolio provides educational analysis...</div>
         </div>
         <div class="border border-gray-700 rounded">
-          <button class="w-full text-left px-4 py-3 flex justify-between items-center faq-question">
+          <button class="w-full text-left px-4 py-3 flex justify-between items-center faq-question" aria-expanded="false" aria-controls="faq2">
             <span>Can I cancel anytime?</span>
-            <span class="text-xl">+</span>
+            <span class="toggle-icon text-xl">+</span>
           </button>
-          <div class="px-4 pb-4 hidden faq-answer">Yes, memberships can be cancelled anytime.</div>
+          <div id="faq2" class="px-4 pb-4 hidden faq-answer" aria-hidden="true">Yes, memberships can be cancelled anytime.</div>
         </div>
       </div>
     </div>
@@ -27,7 +27,12 @@ export default function FAQAccordion() {
   section.querySelectorAll('.faq-question').forEach(btn => {
     btn.addEventListener('click', () => {
       const answer = btn.nextElementSibling;
+      const expanded = btn.getAttribute('aria-expanded') === 'true';
+      btn.setAttribute('aria-expanded', String(!expanded));
       answer.classList.toggle('hidden');
+      answer.setAttribute('aria-hidden', String(expanded));
+      const icon = btn.querySelector('.toggle-icon');
+      icon.textContent = expanded ? '+' : '–';
     });
   });
 

--- a/src/components/featureGrid.js
+++ b/src/components/featureGrid.js
@@ -6,18 +6,18 @@ export default function FeatureGrid() {
     <div class="max-w-7xl mx-auto px-4">
       <h2 class="section-title">What FuzzFolio gives you</h2>
       <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
-        <div class="card text-center">
-          <div class="w-16 h-16 bg-gray-700 rounded mx-auto mb-4"></div>
+        <div class="card text-center transform transition hover:-translate-y-0.5">
+          <div class="w-16 h-16 skeleton rounded mx-auto mb-4" role="img" aria-label="Icon placeholder"><span class="skeleton-label">Icon</span></div>
           <h3 class="font-semibold mb-2">Live market view</h3>
           <p>See clean 5-minute and hourly views with core indicators.</p>
         </div>
-        <div class="card text-center">
-          <div class="w-16 h-16 bg-gray-700 rounded mx-auto mb-4"></div>
+        <div class="card text-center transform transition hover:-translate-y-0.5">
+          <div class="w-16 h-16 skeleton rounded mx-auto mb-4" role="img" aria-label="Icon placeholder"><span class="skeleton-label">Icon</span></div>
           <h3 class="font-semibold mb-2">Real-time alerts</h3>
           <p>Fuzzy logic rolls indicators into a single score.</p>
         </div>
-        <div class="card text-center">
-          <div class="w-16 h-16 bg-gray-700 rounded mx-auto mb-4"></div>
+        <div class="card text-center transform transition hover:-translate-y-0.5">
+          <div class="w-16 h-16 skeleton rounded mx-auto mb-4" role="img" aria-label="Icon placeholder"><span class="skeleton-label">Icon</span></div>
           <h3 class="font-semibold mb-2">Historical log</h3>
           <p>Review past setups and export CSVs to validate.</p>
         </div>

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,7 +1,13 @@
 export default function Footer() {
   const section = document.createElement('footer');
   section.className = 'text-center py-8 text-gray-400 text-sm';
-  section.innerHTML = `© <span id="year"></span> FuzzFolio`;
+  section.innerHTML = `
+    <div class="flex justify-center gap-4 mb-2">
+      <a href="#" class="hover:text-purple-400">Privacy</a>
+      <a href="#" class="hover:text-purple-400">Terms</a>
+      <a href="#" class="hover:text-purple-400">Contact</a>
+    </div>
+    © <span id="year"></span> FuzzFolio`;
   const yearEl = section.querySelector('#year');
   yearEl.textContent = new Date().getFullYear();
   return section;

--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -1,24 +1,20 @@
 export default function HeroSection() {
   const section = document.createElement('section');
-  section.className = 'section relative text-white';
+  section.className = 'section relative text-white bg-hero-gradient';
   section.innerHTML = `
-    <div class="absolute inset-0 overflow-hidden">
-      <img src="https://via.placeholder.com/1600x900" alt="" class="w-full h-full object-cover opacity-60" />
-      <div class="absolute inset-0 bg-gradient-to-r from-black via-purple-900/50 to-black"></div>
-    </div>
-    <div class="relative max-w-7xl mx-auto px-4 flex flex-col lg:flex-row items-center">
+    <div class="max-w-7xl mx-auto px-4 flex flex-col lg:flex-row items-center">
       <div class="flex-1">
-        <h1 class="text-4xl md:text-5xl font-bold">See <span class="text-purple-400">clean setups</span>.<br>Trade on your terms.</h1>
-        <p class="mt-4 max-w-md">FuzzFolio helps you identify optimal trading setups...</p>
+        <h1 class="text-4xl md:text-5xl font-bold">See <span class="text-purple-400">clean setups</span>.<br/>Trade on your terms.</h1>
+        <p class="mt-4 max-w-md">FuzzFolio helps you identify optimal trading setups with AI-powered analysis...</p>
         <div class="mt-8 flex gap-4">
           <a href="#" class="btn-primary">Join Free Setup Radar</a>
           <a href="#" class="btn-secondary">Sample a setup</a>
         </div>
       </div>
       <div class="flex-1 mt-10 lg:mt-0 grid grid-cols-3 gap-4">
-        <div class="card h-32"></div>
-        <div class="card h-32"></div>
-        <div class="card h-32"></div>
+        <div class="card h-32 skeleton transform transition hover:-translate-y-1" role="img" aria-label="Demo tile"><span class="skeleton-label">Demo tile</span></div>
+        <div class="card h-32 skeleton transform transition hover:-translate-y-1" role="img" aria-label="Demo tile"><span class="skeleton-label">Demo tile</span></div>
+        <div class="card h-32 skeleton transform transition hover:-translate-y-1" role="img" aria-label="Demo tile"><span class="skeleton-label">Demo tile</span></div>
       </div>
     </div>
   `;

--- a/src/components/howItWorks.js
+++ b/src/components/howItWorks.js
@@ -5,19 +5,19 @@ export default function HowItWorks() {
   section.innerHTML = `
     <div class="max-w-7xl mx-auto px-4">
       <h2 class="section-title">How it works</h2>
-      <div class="grid md:grid-cols-3 gap-8">
-        <div class="card text-center">
-          <div class="w-12 h-12 bg-gray-700 rounded-full mx-auto mb-4"></div>
+      <div class="relative grid md:grid-cols-3 gap-8 md:before:content-[''] md:before:absolute md:before:top-6 md:before:left-[10%] md:before:right-[10%] md:before:h-px md:before:bg-white/10">
+        <div class="card text-center relative z-10">
+          <div class="w-12 h-12 skeleton rounded-full mx-auto mb-4" role="img" aria-label="Icon placeholder"><span class="skeleton-label">Icon</span></div>
           <h3 class="font-semibold mb-2">Create a profile</h3>
           <p>Use your preferred indicators.</p>
         </div>
-        <div class="card text-center">
-          <div class="w-12 h-12 bg-gray-700 rounded-full mx-auto mb-4"></div>
+        <div class="card text-center relative z-10">
+          <div class="w-12 h-12 skeleton rounded-full mx-auto mb-4" role="img" aria-label="Icon placeholder"><span class="skeleton-label">Icon</span></div>
           <h3 class="font-semibold mb-2">Backtest</h3>
           <p>Iterate quickly on weights.</p>
         </div>
-        <div class="card text-center">
-          <div class="w-12 h-12 bg-gray-700 rounded-full mx-auto mb-4"></div>
+        <div class="card text-center relative z-10">
+          <div class="w-12 h-12 skeleton rounded-full mx-auto mb-4" role="img" aria-label="Icon placeholder"><span class="skeleton-label">Icon</span></div>
           <h3 class="font-semibold mb-2">Go live</h3>
           <p>Receive real-time alerts.</p>
         </div>

--- a/src/components/personaTabs.js
+++ b/src/components/personaTabs.js
@@ -6,32 +6,32 @@ export default function PersonaTabs() {
     <div class="max-w-7xl mx-auto px-4">
       <h2 class="section-title">Who it's for</h2>
       <div class="flex flex-wrap gap-4 justify-center mb-8" role="tablist">
-        <button class="persona-tab btn-secondary" data-target="day">Day Trader</button>
-        <button class="persona-tab btn-secondary" data-target="swing">Swing Trader</button>
-        <button class="persona-tab btn-secondary" data-target="scalper">Scalper</button>
-        <button class="persona-tab btn-secondary" data-target="new">New Trader</button>
-        <button class="persona-tab btn-secondary" data-target="you">You</button>
+        <button id="tab-day" class="persona-tab btn-primary" data-target="day" role="tab" aria-selected="true" aria-controls="panel-day">Day Trader</button>
+        <button id="tab-swing" class="persona-tab btn-secondary" data-target="swing" role="tab" aria-selected="false" aria-controls="panel-swing">Swing Trader</button>
+        <button id="tab-scalper" class="persona-tab btn-secondary" data-target="scalper" role="tab" aria-selected="false" aria-controls="panel-scalper">Scalper</button>
+        <button id="tab-new" class="persona-tab btn-secondary" data-target="new" role="tab" aria-selected="false" aria-controls="panel-new">New Trader</button>
+        <button id="tab-you" class="persona-tab btn-secondary" data-target="you" role="tab" aria-selected="false" aria-controls="panel-you">You</button>
       </div>
       <div class="persona-content max-w-3xl mx-auto">
-        <div data-tab="day" class="tab-panel">
+        <div id="panel-day" data-tab="day" class="tab-panel" role="tabpanel" aria-labelledby="tab-day">
           <p class="mb-4">Day traders can react to real-time scoring alerts and quick backtests.</p>
-          <div class="aspect-video bg-gray-700 rounded"></div>
+          <div class="aspect-[16/9] skeleton" role="img" aria-label="Day trader dashboard preview"><span class="skeleton-label">16:9 preview</span></div>
         </div>
-        <div data-tab="swing" class="tab-panel hidden">
+        <div id="panel-swing" data-tab="swing" class="tab-panel" role="tabpanel" aria-labelledby="tab-swing">
           <p class="mb-4">Swing traders can hold positions with confidence using clear setup scores.</p>
-          <div class="aspect-video bg-gray-700 rounded"></div>
+          <div class="aspect-[16/9] skeleton" role="img" aria-label="Swing trader dashboard preview"><span class="skeleton-label">16:9 preview</span></div>
         </div>
-        <div data-tab="scalper" class="tab-panel hidden">
+        <div id="panel-scalper" data-tab="scalper" class="tab-panel" role="tabpanel" aria-labelledby="tab-scalper">
           <p class="mb-4">Scalpers get fast signals to catch quick moves.</p>
-          <div class="aspect-video bg-gray-700 rounded"></div>
+          <div class="aspect-[16/9] skeleton" role="img" aria-label="Scalper dashboard preview"><span class="skeleton-label">16:9 preview</span></div>
         </div>
-        <div data-tab="new" class="tab-panel hidden">
+        <div id="panel-new" data-tab="new" class="tab-panel" role="tabpanel" aria-labelledby="tab-new">
           <p class="mb-4">New traders learn by seeing clean setups scored in real time.</p>
-          <div class="aspect-video bg-gray-700 rounded"></div>
+          <div class="aspect-[16/9] skeleton" role="img" aria-label="New trader dashboard preview"><span class="skeleton-label">16:9 preview</span></div>
         </div>
-        <div data-tab="you" class="tab-panel hidden">
+        <div id="panel-you" data-tab="you" class="tab-panel" role="tabpanel" aria-labelledby="tab-you">
           <p class="mb-4">Whatever your style, FuzzFolio adapts to you.</p>
-          <div class="aspect-video bg-gray-700 rounded"></div>
+          <div class="aspect-[16/9] skeleton" role="img" aria-label="Personalized dashboard preview"><span class="skeleton-label">16:9 preview</span></div>
         </div>
       </div>
     </div>
@@ -42,13 +42,25 @@ export default function PersonaTabs() {
 
   tabs.forEach(tab => {
     tab.addEventListener('click', () => {
-      tabs.forEach(t => t.classList.remove('btn-primary', 'active'));
-      panels.forEach(p => p.classList.add('hidden'));
+      tabs.forEach(t => {
+        t.classList.remove('btn-primary', 'active');
+        t.classList.add('btn-secondary');
+        t.setAttribute('aria-selected', 'false');
+      });
+      panels.forEach(p => {
+        p.classList.add('hidden');
+        p.setAttribute('aria-hidden', 'true');
+      });
       tab.classList.add('btn-primary', 'active');
-      section.querySelector(`[data-tab="${tab.dataset.target}"]`).classList.remove('hidden');
+      tab.classList.remove('btn-secondary');
+      tab.setAttribute('aria-selected', 'true');
+      const panel = section.querySelector(`#panel-${tab.dataset.target}`);
+      panel.classList.remove('hidden');
+      panel.setAttribute('aria-hidden', 'false');
     });
   });
 
+  // Initialize first tab
   tabs[0].click();
 
   return section;

--- a/src/components/pricingPlans.js
+++ b/src/components/pricingPlans.js
@@ -15,7 +15,8 @@ export default function PricingPlans() {
           </ul>
           <a href="#" class="btn-primary">Join Free</a>
         </div>
-        <div class="card text-center">
+        <div class="card text-center relative">
+          <span class="absolute -top-3 right-4 text-xs bg-purple-600 text-white px-2 py-1 rounded">Best for active traders</span>
           <h3 class="text-xl font-semibold mb-4">Early Access Member — Full Feed</h3>
           <ul class="space-y-2 mb-4">
             <li>Real-time scoring alerts with context</li>

--- a/src/components/statisticBanner.js
+++ b/src/components/statisticBanner.js
@@ -8,10 +8,10 @@ export default function StatisticBanner() {
         <p class="text-sm text-gray-300">Traders trust FuzzFolio</p>
       </div>
       <div class="flex gap-6 overflow-x-auto">
-        <div class="w-24 h-12 bg-gray-700 rounded"></div>
-        <div class="w-24 h-12 bg-gray-700 rounded"></div>
-        <div class="w-24 h-12 bg-gray-700 rounded"></div>
-        <div class="w-24 h-12 bg-gray-700 rounded"></div>
+        <div class="w-28 aspect-[3/1] skeleton" role="img" aria-label="Partner logo placeholder"><span class="skeleton-label">3:1 logo</span></div>
+        <div class="w-28 aspect-[3/1] skeleton" role="img" aria-label="Partner logo placeholder"><span class="skeleton-label">3:1 logo</span></div>
+        <div class="w-28 aspect-[3/1] skeleton" role="img" aria-label="Partner logo placeholder"><span class="skeleton-label">3:1 logo</span></div>
+        <div class="w-28 aspect-[3/1] skeleton" role="img" aria-label="Partner logo placeholder"><span class="skeleton-label">3:1 logo</span></div>
       </div>
     </div>
   `;

--- a/src/components/testimonials.js
+++ b/src/components/testimonials.js
@@ -8,22 +8,31 @@ export default function Testimonials() {
         <div class="card">
           <p class="mb-4">"FuzzFolio helped me spot setups I used to miss."</p>
           <div class="flex items-center gap-2">
-            <div class="w-10 h-10 bg-gray-700 rounded-full"></div>
-            <span>Alex</span>
+            <div class="w-10 h-10 skeleton rounded-full grid place-items-center" role="img" aria-label="Avatar placeholder"><span class="text-xs text-white/80">A</span></div>
+            <div>
+              <span>Alex</span>
+              <p class="text-xs text-gray-400">Swing Trader</p>
+            </div>
           </div>
         </div>
         <div class="card">
           <p class="mb-4">"The scoring system keeps my trades disciplined."</p>
           <div class="flex items-center gap-2">
-            <div class="w-10 h-10 bg-gray-700 rounded-full"></div>
-            <span>Jordan</span>
+            <div class="w-10 h-10 skeleton rounded-full grid place-items-center" role="img" aria-label="Avatar placeholder"><span class="text-xs text-white/80">J</span></div>
+            <div>
+              <span>Jordan</span>
+              <p class="text-xs text-gray-400">Day Trader</p>
+            </div>
           </div>
         </div>
         <div class="card">
           <p class="mb-4">"Backtesting is fast and easy to tweak."</p>
           <div class="flex items-center gap-2">
-            <div class="w-10 h-10 bg-gray-700 rounded-full"></div>
-            <span>Taylor</span>
+            <div class="w-10 h-10 skeleton rounded-full grid place-items-center" role="img" aria-label="Avatar placeholder"><span class="text-xs text-white/80">T</span></div>
+            <div>
+              <span>Taylor</span>
+              <p class="text-xs text-gray-400">Scalper</p>
+            </div>
           </div>
         </div>
       </div>

--- a/src/main.js
+++ b/src/main.js
@@ -26,3 +26,11 @@ const app = document.getElementById('app');
   CTASection,
   Footer
 ].forEach(Component => app.appendChild(Component()));
+
+const navToggle = document.getElementById('mobile-toggle');
+const navMenu = document.getElementById('nav-menu');
+if (navToggle && navMenu) {
+  navToggle.addEventListener('click', () => {
+    navMenu.classList.toggle('hidden');
+  });
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,5 +1,35 @@
 @import "tailwindcss";
 
+@layer utilities {
+  /* Gradient tokens for hero + accents */
+  .bg-hero-gradient {
+    /* multiple layers: soft vignette + directional glow */
+    background-image:
+      radial-gradient(60% 80% at 10% 0%, rgba(168,85,247,0.30), transparent 60%),
+      radial-gradient(40% 40% at 85% 35%, rgba(236,72,153,0.25), transparent 60%),
+      linear-gradient(180deg, rgba(2,6,23,1) 0%, rgba(2,6,23,0.85) 100%);
+  }
+
+  /* Informative skeleton */
+  .skeleton {
+    @apply relative overflow-hidden bg-slate-800/70 rounded-lg border border-white/5;
+  }
+  .skeleton::after {
+    content: "";
+    position: absolute; inset: 0;
+    background-image: linear-gradient(90deg, transparent, rgba(255,255,255,.08), transparent);
+    transform: translateX(-100%);
+    animation: shimmer 1.75s infinite;
+  }
+  @keyframes shimmer { 100% { transform: translateX(100%); } }
+
+  /* Small label for aspect ratio or caption */
+  .skeleton-label {
+    @apply absolute bottom-2 right-2 text-[11px] tracking-wide uppercase bg-black/50
+           text-white/80 px-2 py-0.5 rounded;
+  }
+}
+
 @layer components {
   .btn-primary {
     @apply px-4 py-2 rounded-md bg-purple-600 text-white font-semibold shadow hover:shadow-lg transition;


### PR DESCRIPTION
## Summary
- add gradient, skeleton, and token utilities
- redesign hero and sections with informative skeletons and hover states
- improve accessibility and navigation with ARIA, mobile menu, and footer links

## Testing
- `npm ci`
- `npm run build`

```
> fuzzfolio-landing@1.0.0 build
> vite build

vite v7.1.3 building for production...
transforming...
✓ 15 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                  1.42 kB │ gzip: 0.74 kB
dist/assets/index-CdWEdONe.css  22.43 kB │ gzip: 4.67 kB
dist/assets/index-Be7t33Lk.js   16.17 kB │ gzip: 3.64 kB
✓ built in 252ms
```


------
https://chatgpt.com/codex/tasks/task_e_68b609ddd6ec83258df6cac234461631