### PR TITLE
chore: polish mobile layout and gradients

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,18 +8,26 @@
 </head>
 <body class="font-[Inter] bg-slate-950 text-white">
   <header class="sticky top-0 z-50 bg-slate-900/80 backdrop-blur">
-    <nav class="max-w-7xl mx-auto flex items-center justify-between p-4 relative">
+    <nav class="max-w-7xl mx-auto container-pad py-4 flex items-center justify-between">
       <div class="font-bold text-xl">FuzzFolio</div>
-      <button id="mobile-toggle" class="md:hidden" aria-label="Toggle navigation">
-        <span class="text-2xl">☰</span>
-      </button>
-      <div id="nav-menu" class="hidden flex-col gap-4 absolute top-full left-0 w-full bg-slate-900/90 p-4 md:static md:flex md:flex-row md:gap-6 md:w-auto md:bg-transparent md:p-0 items-center">
-        <a href="#features" class="hover:text-purple-400">Features</a>
-        <a href="#plans" class="hover:text-purple-400">Plans</a>
-        <a href="#faq" class="hover:text-purple-400">FAQ</a>
+      <button id="menu-toggle" class="md:hidden p-2 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40" aria-expanded="false" aria-controls="mobile-menu">☰</button>
+      <div class="hidden md:flex gap-6 items-center">
+        <a href="#features" class="hover:text-purple-400 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Features</a>
+        <a href="#plans" class="hover:text-purple-400 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Plans</a>
+        <a href="#faq" class="hover:text-purple-400 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">FAQ</a>
         <a href="#cta" class="btn-primary text-sm">Join Free Setup Radar</a>
       </div>
     </nav>
+    <div id="mobile-menu" class="fixed inset-x-0 top-14 z-50 hidden">
+      <div class="mx-3 rounded-xl bg-slate-900/95 backdrop-blur border border-white/10 shadow-lg">
+        <a href="#features" class="block px-4 py-3 border-b border-white/10 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Features</a>
+        <a href="#plans" class="block px-4 py-3 border-b border-white/10 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Plans</a>
+        <a href="#faq" class="block px-4 py-3 border-b border-white/10 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">FAQ</a>
+        <a href="#" class="block px-4 py-3 text-center focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">
+          <span class="btn-primary inline-block w-full">Join Free Setup Radar</span>
+        </a>
+      </div>
+    </div>
   </header>
   <main id="app"></main>
   <script type="module" src="/src/main.js"></script>

--- a/src/components/backtestingSection.js
+++ b/src/components/backtestingSection.js
@@ -3,7 +3,7 @@ export default function BacktestingSection() {
   section.id = 'backtesting';
   section.className = 'section bg-slate-900';
   section.innerHTML = `
-    <div class="max-w-7xl mx-auto px-4 grid md:grid-cols-2 gap-8 items-center">
+    <div class="max-w-7xl mx-auto container-pad grid md:grid-cols-2 gap-8 items-center">
       <div>
         <h2 class="section-title text-left md:text-left">Backtesting built in</h2>
         <p class="mb-4">Validate a scoring profile with the same engine that powers live alerts.</p>

--- a/src/components/ctaSection.js
+++ b/src/components/ctaSection.js
@@ -1,14 +1,16 @@
 export default function CTASection() {
   const section = document.createElement('section');
   section.id = 'cta';
-  section.className = 'section bg-gradient-to-r from-purple-600 to-pink-600 text-center';
+  section.className = 'section bg-cta-gradient text-center';
   section.innerHTML = `
-    <h2 class="text-3xl font-bold mb-6">Ready to see clean setups?</h2>
-    <div class="flex flex-col sm:flex-row gap-4 justify-center">
-      <a href="#" class="btn-primary">Join Free Setup Radar</a>
-      <a href="#" class="btn-secondary">Become an Early Access Member</a>
+    <div class="max-w-3xl mx-auto container-pad">
+      <h2 class="text-3xl font-bold mb-6">Ready to see clean setups?</h2>
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <a href="#" class="btn-primary">Join Free Setup Radar</a>
+        <a href="#" class="btn-secondary">Become an Early Access Member</a>
+      </div>
+      <p class="mt-4 text-white/80 text-sm">No credit card required.</p>
     </div>
-    <p class="mt-4 text-sm text-white/80">No credit card required.</p>
   `;
   return section;
 }

--- a/src/components/faqAccordion.js
+++ b/src/components/faqAccordion.js
@@ -3,20 +3,20 @@ export default function FAQAccordion() {
   section.id = 'faq';
   section.className = 'section bg-slate-900';
   section.innerHTML = `
-    <div class="max-w-7xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto container-pad">
       <h2 class="section-title">FAQ</h2>
       <div class="space-y-4">
         <div class="border border-gray-700 rounded">
-          <button class="w-full text-left px-4 py-3 flex justify-between items-center faq-question" aria-expanded="false" aria-controls="faq1">
+          <button class="w-full text-left px-4 py-3 flex justify-between items-center faq-question focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40" aria-expanded="false" aria-controls="faq1">
             <span>Is this financial advice?</span>
-            <span class="toggle-icon text-xl">+</span>
+            <span class="faq-icon text-xl">+</span>
           </button>
           <div id="faq1" class="px-4 pb-4 hidden faq-answer" aria-hidden="true">No. FuzzFolio provides educational analysis...</div>
         </div>
         <div class="border border-gray-700 rounded">
-          <button class="w-full text-left px-4 py-3 flex justify-between items-center faq-question" aria-expanded="false" aria-controls="faq2">
+          <button class="w-full text-left px-4 py-3 flex justify-between items-center faq-question focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40" aria-expanded="false" aria-controls="faq2">
             <span>Can I cancel anytime?</span>
-            <span class="toggle-icon text-xl">+</span>
+            <span class="faq-icon text-xl">+</span>
           </button>
           <div id="faq2" class="px-4 pb-4 hidden faq-answer" aria-hidden="true">Yes, memberships can be cancelled anytime.</div>
         </div>
@@ -27,12 +27,10 @@ export default function FAQAccordion() {
   section.querySelectorAll('.faq-question').forEach(btn => {
     btn.addEventListener('click', () => {
       const answer = btn.nextElementSibling;
-      const expanded = btn.getAttribute('aria-expanded') === 'true';
-      btn.setAttribute('aria-expanded', String(!expanded));
-      answer.classList.toggle('hidden');
-      answer.setAttribute('aria-hidden', String(expanded));
-      const icon = btn.querySelector('.toggle-icon');
-      icon.textContent = expanded ? '+' : '–';
+      const open = answer.classList.toggle('hidden') === false;
+      btn.querySelector('.faq-icon')?.replaceChildren(document.createTextNode(open ? '–' : '+'));
+      btn.setAttribute('aria-expanded', String(open));
+      answer.setAttribute('aria-hidden', String(!open));
     });
   });
 

--- a/src/components/featureGrid.js
+++ b/src/components/featureGrid.js
@@ -3,23 +3,36 @@ export default function FeatureGrid() {
   section.id = 'features';
   section.className = 'section';
   section.innerHTML = `
-    <div class="max-w-7xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto container-pad">
       <h2 class="section-title">What FuzzFolio gives you</h2>
-      <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
-        <div class="card text-center transform transition hover:-translate-y-0.5">
-          <div class="w-16 h-16 skeleton rounded mx-auto mb-4" role="img" aria-label="Icon placeholder"><span class="skeleton-label">Icon</span></div>
+
+      <div class="grid gap-4 sm:gap-6 grid-cols-2 md:grid-cols-4">
+        <!-- Live market view -->
+        <div class="card text-center">
+          <div class="w-16 aspect-square skeleton rounded mx-auto mb-4" role="img" aria-label="Icon placeholder"><span class="skeleton-label">Icon</span></div>
           <h3 class="font-semibold mb-2">Live market view</h3>
-          <p>See clean 5-minute and hourly views with core indicators.</p>
+          <p>Clean 5-minute and hourly views with core indicators.</p>
         </div>
-        <div class="card text-center transform transition hover:-translate-y-0.5">
-          <div class="w-16 h-16 skeleton rounded mx-auto mb-4" role="img" aria-label="Icon placeholder"><span class="skeleton-label">Icon</span></div>
+
+        <!-- Real-time alerts -->
+        <div class="card text-center">
+          <div class="w-16 aspect-square skeleton rounded mx-auto mb-4" role="img" aria-label="Icon placeholder"><span class="skeleton-label">Icon</span></div>
           <h3 class="font-semibold mb-2">Real-time alerts</h3>
           <p>Fuzzy logic rolls indicators into a single score.</p>
         </div>
-        <div class="card text-center transform transition hover:-translate-y-0.5">
-          <div class="w-16 h-16 skeleton rounded mx-auto mb-4" role="img" aria-label="Icon placeholder"><span class="skeleton-label">Icon</span></div>
+
+        <!-- Historical log -->
+        <div class="card text-center">
+          <div class="w-16 aspect-square skeleton rounded mx-auto mb-4" role="img" aria-label="Icon placeholder"><span class="skeleton-label">Icon</span></div>
           <h3 class="font-semibold mb-2">Historical log</h3>
           <p>Review past setups and export CSVs to validate.</p>
+        </div>
+
+        <!-- NEW: Backtesting -->
+        <div class="card text-center">
+          <div class="w-16 aspect-square skeleton rounded mx-auto mb-4" role="img" aria-label="Icon placeholder"><span class="skeleton-label">Icon</span></div>
+          <h3 class="font-semibold mb-2">Backtesting</h3>
+          <p>Validate scoring profiles quickly with transparent context.</p>
         </div>
       </div>
     </div>

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -2,12 +2,14 @@ export default function Footer() {
   const section = document.createElement('footer');
   section.className = 'text-center py-8 text-gray-400 text-sm';
   section.innerHTML = `
-    <div class="flex justify-center gap-4 mb-2">
-      <a href="#" class="hover:text-purple-400">Privacy</a>
-      <a href="#" class="hover:text-purple-400">Terms</a>
-      <a href="#" class="hover:text-purple-400">Contact</a>
-    </div>
-    © <span id="year"></span> FuzzFolio`;
+    <div class="max-w-7xl mx-auto container-pad">
+      <div class="flex justify-center gap-4 mb-2">
+        <a href="#" class="hover:text-purple-400 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Privacy</a>
+        <a href="#" class="hover:text-purple-400 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Terms</a>
+        <a href="#" class="hover:text-purple-400 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Contact</a>
+      </div>
+      © <span id="year"></span> FuzzFolio
+    </div>`;
   const yearEl = section.querySelector('#year');
   yearEl.textContent = new Date().getFullYear();
   return section;

--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -2,19 +2,21 @@ export default function HeroSection() {
   const section = document.createElement('section');
   section.className = 'section relative text-white bg-hero-gradient';
   section.innerHTML = `
-    <div class="max-w-7xl mx-auto px-4 flex flex-col lg:flex-row items-center">
+    <div class="max-w-7xl mx-auto container-pad flex flex-col lg:flex-row items-center">
       <div class="flex-1">
-        <h1 class="text-4xl md:text-5xl font-bold">See <span class="text-purple-400">clean setups</span>.<br/>Trade on your terms.</h1>
+        <h1 class="text-4xl sm:text-6xl md:text-7xl font-bold">See <span class="text-purple-400">clean setups</span>.<br/>Trade on your terms.</h1>
         <p class="mt-4 max-w-md">FuzzFolio helps you identify optimal trading setups with AI-powered analysis...</p>
         <div class="mt-8 flex gap-4">
           <a href="#" class="btn-primary">Join Free Setup Radar</a>
           <a href="#" class="btn-secondary">Sample a setup</a>
         </div>
       </div>
-      <div class="flex-1 mt-10 lg:mt-0 grid grid-cols-3 gap-4">
-        <div class="card h-32 skeleton transform transition hover:-translate-y-1" role="img" aria-label="Demo tile"><span class="skeleton-label">Demo tile</span></div>
-        <div class="card h-32 skeleton transform transition hover:-translate-y-1" role="img" aria-label="Demo tile"><span class="skeleton-label">Demo tile</span></div>
-        <div class="card h-32 skeleton transform transition hover:-translate-y-1" role="img" aria-label="Demo tile"><span class="skeleton-label">Demo tile</span></div>
+      <div class="flex-1 mt-8 lg:mt-0">
+        <div class="grid grid-cols-3 gap-3 sm:gap-4 w-full">
+          <div class="skeleton rounded-xl aspect-[9/16] sm:aspect-[3/5] md:aspect-[4/5]" role="img" aria-label="9:16 tile"><span class="skeleton-label">9:16 tile</span></div>
+          <div class="skeleton rounded-xl aspect-[9/16] sm:aspect-[3/5] md:aspect-[4/5]" role="img" aria-label="9:16 tile"><span class="skeleton-label">9:16 tile</span></div>
+          <div class="skeleton rounded-xl aspect-[9/16] sm:aspect-[3/5] md:aspect-[4/5]" role="img" aria-label="9:16 tile"><span class="skeleton-label">9:16 tile</span></div>
+        </div>
       </div>
     </div>
   `;

--- a/src/components/howItWorks.js
+++ b/src/components/howItWorks.js
@@ -3,7 +3,7 @@ export default function HowItWorks() {
   section.id = 'how';
   section.className = 'section';
   section.innerHTML = `
-    <div class="max-w-7xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto container-pad">
       <h2 class="section-title">How it works</h2>
       <div class="relative grid md:grid-cols-3 gap-8 md:before:content-[''] md:before:absolute md:before:top-6 md:before:left-[10%] md:before:right-[10%] md:before:h-px md:before:bg-white/10">
         <div class="card text-center relative z-10">

--- a/src/components/personaTabs.js
+++ b/src/components/personaTabs.js
@@ -3,7 +3,7 @@ export default function PersonaTabs() {
   section.id = 'personas';
   section.className = 'section bg-slate-900';
   section.innerHTML = `
-    <div class="max-w-7xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto container-pad">
       <h2 class="section-title">Who it's for</h2>
       <div class="flex flex-wrap gap-4 justify-center mb-8" role="tablist">
         <button id="tab-day" class="persona-tab btn-primary" data-target="day" role="tab" aria-selected="true" aria-controls="panel-day">Day Trader</button>

--- a/src/components/pricingPlans.js
+++ b/src/components/pricingPlans.js
@@ -3,7 +3,7 @@ export default function PricingPlans() {
   section.id = 'plans';
   section.className = 'section bg-slate-900';
   section.innerHTML = `
-    <div class="max-w-7xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto container-pad">
       <h2 class="section-title">Plans</h2>
       <div class="grid md:grid-cols-2 gap-8">
         <div class="card text-center">

--- a/src/components/statisticBanner.js
+++ b/src/components/statisticBanner.js
@@ -1,17 +1,20 @@
 export default function StatisticBanner() {
   const section = document.createElement('section');
-  section.className = 'bg-slate-800 py-10';
+  section.className = 'bg-slate-800/60 py-10';
   section.innerHTML = `
-    <div class="max-w-7xl mx-auto px-4 flex flex-col md:flex-row items-center justify-between gap-8">
-      <div class="text-center md:text-left">
-        <p class="text-3xl font-bold">5,000+</p>
-        <p class="text-sm text-gray-300">Traders trust FuzzFolio</p>
-      </div>
-      <div class="flex gap-6 overflow-x-auto">
-        <div class="w-28 aspect-[3/1] skeleton" role="img" aria-label="Partner logo placeholder"><span class="skeleton-label">3:1 logo</span></div>
-        <div class="w-28 aspect-[3/1] skeleton" role="img" aria-label="Partner logo placeholder"><span class="skeleton-label">3:1 logo</span></div>
-        <div class="w-28 aspect-[3/1] skeleton" role="img" aria-label="Partner logo placeholder"><span class="skeleton-label">3:1 logo</span></div>
-        <div class="w-28 aspect-[3/1] skeleton" role="img" aria-label="Partner logo placeholder"><span class="skeleton-label">3:1 logo</span></div>
+    <div class="max-w-7xl mx-auto container-pad">
+      <div class="card p-6 md:p-8">
+        <div class="text-center mb-6">
+          <p class="text-3xl font-bold">5,000+</p>
+          <p class="text-sm text-gray-300">Traders trust FuzzFolio</p>
+        </div>
+
+        <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 place-items-center">
+          <div class="w-28 sm:w-32 aspect-[3/1] skeleton" role="img" aria-label="3:1 logo"><span class="skeleton-label">3:1 logo</span></div>
+          <div class="w-28 sm:w-32 aspect-[3/1] skeleton" role="img" aria-label="3:1 logo"><span class="skeleton-label">3:1 logo</span></div>
+          <div class="w-28 sm:w-32 aspect-[3/1] skeleton" role="img" aria-label="3:1 logo"><span class="skeleton-label">3:1 logo</span></div>
+          <div class="w-28 sm:w-32 aspect-[3/1] skeleton" role="img" aria-label="3:1 logo"><span class="skeleton-label">3:1 logo</span></div>
+        </div>
       </div>
     </div>
   `;

--- a/src/components/testimonials.js
+++ b/src/components/testimonials.js
@@ -2,7 +2,7 @@ export default function Testimonials() {
   const section = document.createElement('section');
   section.className = 'section';
   section.innerHTML = `
-    <div class="max-w-7xl mx-auto px-4">
+    <div class="max-w-7xl mx-auto container-pad">
       <h2 class="section-title">Traders say</h2>
       <div class="grid md:grid-cols-3 gap-8">
         <div class="card">

--- a/src/main.js
+++ b/src/main.js
@@ -27,10 +27,9 @@ const app = document.getElementById('app');
   Footer
 ].forEach(Component => app.appendChild(Component()));
 
-const navToggle = document.getElementById('mobile-toggle');
-const navMenu = document.getElementById('nav-menu');
-if (navToggle && navMenu) {
-  navToggle.addEventListener('click', () => {
-    navMenu.classList.toggle('hidden');
-  });
-}
+const btn = document.getElementById('menu-toggle');
+const menu = document.getElementById('mobile-menu');
+btn?.addEventListener('click', () => {
+  const open = menu.classList.toggle('hidden');
+  btn.setAttribute('aria-expanded', String(!open));
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,11 +3,28 @@
 @layer utilities {
   /* Gradient tokens for hero + accents */
   .bg-hero-gradient {
-    /* multiple layers: soft vignette + directional glow */
     background-image:
-      radial-gradient(60% 80% at 10% 0%, rgba(168,85,247,0.30), transparent 60%),
-      radial-gradient(40% 40% at 85% 35%, rgba(236,72,153,0.25), transparent 60%),
-      linear-gradient(180deg, rgba(2,6,23,1) 0%, rgba(2,6,23,0.85) 100%);
+      radial-gradient(140% 120% at 0% 0%, rgba(168,85,247,.35), transparent 60%),
+      radial-gradient(140% 120% at 100% 0%, rgba(236,72,153,.30), transparent 55%),
+      linear-gradient(180deg, #0b1220 0%, #0b1220 100%);
+  }
+
+  /* Better mobile-safe section gutters */
+  .container-pad { @apply px-4 sm:px-6; }
+
+  /* Edge-fade masks for scroll areas (if we keep horizontal scroll anywhere) */
+  .edge-fade {
+    --fade: linear-gradient(90deg, rgba(2,6,23,1) 0%, rgba(2,6,23,0) 12%, rgba(2,6,23,0) 88%, rgba(2,6,23,1) 100%);
+    -webkit-mask-image: var(--fade);
+            mask-image: var(--fade);
+  }
+
+  /* Nicer CTA gradient (remove teal cast) */
+  .bg-cta-gradient {
+    background-image:
+      radial-gradient(140% 120% at 0% 0%, rgba(168,85,247,.40), transparent 60%),
+      radial-gradient(140% 120% at 100% 0%, rgba(236,72,153,.35), transparent 55%),
+      linear-gradient(180deg, #0b1220 0%, #0b1220 100%);
   }
 
   /* Informative skeleton */
@@ -32,10 +49,10 @@
 
 @layer components {
   .btn-primary {
-    @apply px-4 py-2 rounded-md bg-purple-600 text-white font-semibold shadow hover:shadow-lg transition;
+    @apply px-4 py-2 rounded-lg bg-purple-600 text-white font-semibold shadow hover:shadow-lg transition focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40;
   }
   .btn-secondary {
-    @apply px-4 py-2 rounded-md border border-purple-600 text-purple-600 font-semibold hover:bg-purple-600 hover:text-white transition;
+    @apply px-4 py-2 rounded-lg border border-purple-600 text-purple-600 font-semibold hover:bg-purple-600 hover:text-white transition focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40;
   }
   .section {
     @apply py-20;
@@ -44,6 +61,6 @@
     @apply text-3xl font-bold text-center mb-8;
   }
   .card {
-    @apply bg-white/10 backdrop-blur rounded-lg p-6 shadow;
+    @apply bg-white/10 backdrop-blur rounded-2xl p-6 shadow;
   }
 }


### PR DESCRIPTION
## Summary
- upgrade hero tiles and CTA gradient
- add overlay mobile menu and unify section gutters
- refine feature list, stats banner, and FAQ interactions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b614531ae88325aa9a056e487789cf