### PR TITLE
chore: constrain platform and backtesting frames

### DIFF
--- a/src/components/backtestingSection.js
+++ b/src/components/backtestingSection.js
@@ -3,19 +3,21 @@ export default function BacktestingSection() {
   section.id = 'backtesting';
   section.className = 'section';
   section.innerHTML = `
-    <div class="max-w-7xl mx-auto container-pad frame p-6 sm:p-8">
-      <div class="grid md:grid-cols-2 gap-8 items-center">
-        <div>
-          <span class="kicker">Backtesting</span>
-          <h2 class="text-2xl sm:text-3xl font-bold mt-2">Backtesting built in</h2>
-          <ul class="list-disc ml-5 mt-4 space-y-2">
-            <li>Configurable lookbacks</li>
-            <li>Fast iteration on weights</li>
-            <li>Traceable outcomes with price context</li>
-          </ul>
-        </div>
-        <div class="skeleton rounded-2xl aspect-[16/9]" role="img" aria-label="Backtest chart mockup">
-          <span class="skeleton-label">16:9</span>
+    <div class="max-w-7xl mx-auto container-pad">
+      <div class="frame p-6 sm:p-8">
+        <div class="grid md:grid-cols-2 gap-8 items-center">
+          <div>
+            <span class="kicker">Backtesting</span>
+            <h2 class="text-2xl sm:text-3xl font-bold mt-2">Backtesting built in</h2>
+            <ul class="list-disc ml-5 mt-4 space-y-2">
+              <li>Configurable lookbacks</li>
+              <li>Fast iteration on weights</li>
+              <li>Traceable outcomes with price context</li>
+            </ul>
+          </div>
+          <div class="skeleton rounded-2xl aspect-[16/9]" role="img" aria-label="Backtest chart mockup">
+            <span class="skeleton-label">16:9</span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/featureGrid.js
+++ b/src/components/featureGrid.js
@@ -3,10 +3,11 @@ export default function FeatureGrid() {
   section.id = 'features';
   section.className = 'section';
   section.innerHTML = `
-    <div class="max-w-7xl mx-auto container-pad frame frame-glow p-6 sm:p-8">
-      <span class="kicker">Platform</span>
-      <h2 class="section-title mt-2">What FuzzFolio gives you</h2>
-      <div class="grid grid-cols-2 md:grid-cols-4 gap-4 sm:gap-6">
+    <div class="max-w-7xl mx-auto container-pad">
+      <div class="frame frame-glow p-6 sm:p-8">
+        <span class="kicker">Platform</span>
+        <h2 class="section-title mt-2">What FuzzFolio gives you</h2>
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-4 sm:gap-6">
         <!-- Live market view -->
         <article class="card text-center">
           <div class="w-16 aspect-square skeleton rounded mx-auto mb-4" role="img" aria-label="Icon"><span class="skeleton-label">Icon</span></div>
@@ -34,6 +35,7 @@ export default function FeatureGrid() {
           <h3 class="font-semibold mb-2">Backtesting</h3>
           <p>Validate scoring profiles quickly with transparent context.</p>
         </article>
+        </div>
       </div>
     </div>
   `;


### PR DESCRIPTION
## Summary
- wrap Platform feature grid in standard container to avoid full-width frame
- apply same container + padding structure to Backtesting section

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b65740495883259e5a7af236d29f72