### PR TITLE
Refactor mobile menu overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,14 +17,20 @@
         <a href="#cta" class="cta-primary cta-pill text-sm">Get Setups</a>
       </div>
     </nav>
-    <div id="mobile-menu" class="fixed inset-0 z-50 hidden">
-      <div class="h-full w-full bg-slate-900/95 backdrop-blur flex flex-col items-center justify-center gap-6 text-lg">
+  </header>
+  <div id="mobile-menu" class="fixed inset-0 z-[60] hidden">
+    <div class="h-full w-full bg-slate-900/95 backdrop-blur flex flex-col">
+      <div class="flex items-center justify-between p-4">
+        <div class="font-bold text-xl">FuzzFolio</div>
+        <button id="menu-close" class="p-2 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">✕</button>
+      </div>
+      <nav class="mt-10 flex flex-col items-center gap-6 text-lg">
         <a href="#features" class="focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Features</a>
         <a href="#plans" class="focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Plans</a>
-        <a href="#" class="cta-primary cta-pill focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Get Setups</a>
-      </div>
+        <a href="#cta" class="cta-primary cta-pill focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Get Setups</a>
+      </nav>
     </div>
-  </header>
+  </div>
   <main id="app"></main>
   <script type="module" src="/src/main.js"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -25,7 +25,20 @@ const app = document.getElementById('app');
 
 const btn = document.getElementById('menu-toggle');
 const menu = document.getElementById('mobile-menu');
-btn?.addEventListener('click', () => {
-  const open = menu.classList.toggle('hidden');
-  btn.setAttribute('aria-expanded', String(!open));
-});
+const closeBtn = document.getElementById('menu-close');
+
+function openMenu() {
+  menu.classList.remove('hidden');
+  btn.setAttribute('aria-expanded', 'true');
+  document.body.classList.add('overflow-hidden');
+}
+
+function closeMenu() {
+  menu.classList.add('hidden');
+  btn.setAttribute('aria-expanded', 'false');
+  document.body.classList.remove('overflow-hidden');
+}
+
+btn?.addEventListener('click', openMenu);
+closeBtn?.addEventListener('click', closeMenu);
+menu?.querySelectorAll('a')?.forEach(link => link.addEventListener('click', closeMenu));


### PR DESCRIPTION
## Summary
- Rebuild mobile menu as a full-screen overlay with close button
- Lock body scroll and close menu when links are clicked

## Testing
- `npm run build`
```
vite v7.1.3 building for production...
transforming...
✓ 13 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                  2.32 kB │ gzip: 0.83 kB
dist/assets/index-B6-OfLmZ.css  27.61 kB │ gzip: 4.97 kB
dist/assets/index-BoecjH6Y.js   12.75 kB │ gzip: 2.85 kB
✓ built in 268ms
```


------
https://chatgpt.com/codex/tasks/task_e_68b6e5ef372c83259beb3bc64e0eacb8