### PR TITLE
Restore FAQ section to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
       <div class="hidden md:flex gap-6 items-center">
         <a href="#features" class="hover:text-purple-400 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Features</a>
         <a href="#plans" class="hover:text-purple-400 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Plans</a>
+        <a href="#faq" class="hover:text-purple-400 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">FAQ</a>
         <a href="#cta" class="cta-primary cta-pill text-sm">Get Setups</a>
       </div>
     </nav>
@@ -27,6 +28,7 @@
       <nav class="mt-10 flex flex-col items-center gap-6 text-lg">
         <a href="#features" class="focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Features</a>
         <a href="#plans" class="focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Plans</a>
+        <a href="#faq" class="focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">FAQ</a>
         <a href="#cta" class="cta-primary cta-pill focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Get Setups</a>
       </nav>
     </div>

--- a/src/components/faqAccordion.js
+++ b/src/components/faqAccordion.js
@@ -5,20 +5,24 @@ export default function FAQAccordion() {
   section.innerHTML = `
     <div class="max-w-7xl mx-auto container-pad">
       <h2 class="section-title">FAQ</h2>
-      <div class="space-y-4">
-        <div class="border border-gray-700 rounded">
+      <div class="space-y-4 max-w-3xl mx-auto">
+        <div class="frame frame-ghost overflow-hidden">
           <button class="w-full text-left px-4 py-3 flex justify-between items-center faq-question focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40" aria-expanded="false" aria-controls="faq1">
             <span>Is this financial advice?</span>
             <span class="faq-icon text-xl">+</span>
           </button>
-          <div id="faq1" class="px-4 pb-4 hidden faq-answer" aria-hidden="true">No. FuzzFolio provides educational analysis...</div>
+          <div id="faq1" class="px-4 pb-4 hidden faq-answer" aria-hidden="true">
+            No. FuzzFolio provides educational analysis...
+          </div>
         </div>
-        <div class="border border-gray-700 rounded">
+        <div class="frame frame-ghost overflow-hidden">
           <button class="w-full text-left px-4 py-3 flex justify-between items-center faq-question focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40" aria-expanded="false" aria-controls="faq2">
             <span>Can I cancel anytime?</span>
             <span class="faq-icon text-xl">+</span>
           </button>
-          <div id="faq2" class="px-4 pb-4 hidden faq-answer" aria-hidden="true">Yes, memberships can be cancelled anytime.</div>
+          <div id="faq2" class="px-4 pb-4 hidden faq-answer" aria-hidden="true">
+            Yes, memberships can be cancelled anytime.
+          </div>
         </div>
       </div>
     </div>

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import ShowcaseSection from './components/showcaseSection.js';
 import StatisticBanner from './components/statisticBanner.js';
 import BacktestingSection from './components/backtestingSection.js';
 import PricingPlans from './components/pricingPlans.js';
+import FAQAccordion from './components/faqAccordion.js';
 import Testimonials from './components/testimonials.js';
 import CTASection from './components/ctaSection.js';
 import Footer from './components/footer.js';
@@ -18,6 +19,7 @@ const app = document.getElementById('app');
   StatisticBanner,
   BacktestingSection,
   PricingPlans,
+  FAQAccordion,
   Testimonials,
   CTASection,
   Footer


### PR DESCRIPTION
## Summary
- reinstate FAQ accordion component and mount it in main entry
- add FAQ navigation links and align styling with existing frames

## Testing
- `npm ci`
- `npm run build`
```text
vite v7.1.3 building for production...
transforming...
✓ 14 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                  2.58 kB │ gzip: 0.84 kB
dist/assets/index-DLp4LQpC.css  27.45 kB │ gzip: 4.94 kB
dist/assets/index-ERuYmCnI.js   14.50 kB │ gzip: 3.24 kB
✓ built in 278ms
```


------
https://chatgpt.com/codex/tasks/task_e_68b6e986809c83258347618a26ba2f69