### PR TITLE
Add missing kicker badges to sections

### DIFF
--- a/src/components/ctaSection.js
+++ b/src/components/ctaSection.js
@@ -7,7 +7,8 @@ export default function CTASection() {
       <div class="frame p-8 text-center" style="background-image:
         radial-gradient(120% 90% at 0% 0%, rgba(168,85,247,.25), transparent 60%),
         radial-gradient(120% 90% at 100% 0%, rgba(236,72,153,.20), transparent 55%);">
-        <h2 class="text-3xl font-bold">Ready to see clean setups?</h2>
+        <span class="kicker">Join</span>
+        <h2 class="text-3xl font-bold mt-2">Ready to see clean setups?</h2>
         <div class="mt-6 flex flex-col sm:flex-row gap-3 justify-center">
           <a href="#" class="cta-primary cta-pill">Get Setups</a>
           <a href="#" class="cta-secondary cta-pill">Join on Telegram</a>

--- a/src/components/faqAccordion.js
+++ b/src/components/faqAccordion.js
@@ -4,7 +4,8 @@ export default function FAQAccordion() {
   section.className = 'section bg-slate-900';
   section.innerHTML = `
     <div class="max-w-7xl mx-auto container-pad">
-      <h2 class="section-title">FAQ</h2>
+      <span class="kicker">Support</span>
+      <h2 class="section-title mt-2">FAQ</h2>
       <div class="space-y-4 max-w-3xl mx-auto">
         <div class="frame frame-ghost overflow-hidden">
           <button class="w-full text-left px-4 py-3 flex justify-between items-center faq-question focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40" aria-expanded="false" aria-controls="faq1">

--- a/src/components/statisticBanner.js
+++ b/src/components/statisticBanner.js
@@ -4,7 +4,8 @@ export default function StatisticBanner() {
   section.innerHTML = `
     <div class="max-w-7xl mx-auto container-pad">
       <div class="frame frame-glow p-6 sm:p-8 text-center">
-        <p class="text-3xl font-bold">5,000+</p>
+        <span class="kicker">Community</span>
+        <p class="text-3xl font-bold mt-2">5,000+</p>
         <p class="text-sm text-gray-300 mb-6">Traders trust FuzzFolio</p>
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 place-items-center">
           <div class="w-28 sm:w-32 aspect-[3/1] skeleton" role="img" aria-label="Logo placeholder"><span class="skeleton-label">3:1</span></div>


### PR DESCRIPTION
## Summary
- add missing kicker badges for FAQ, CTA, and stats sections

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6eda281a48325a31d95e1d2b713da