### PR TITLE
revamp typography and add gradient utilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,11 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>FuzzFolio</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 </head>
-<body class="font-[Inter] app-bg text-white">
+<body class="app-bg text-white">
   <header class="sticky top-0 z-50 bg-slate-900/80 backdrop-blur">
     <nav class="max-w-7xl mx-auto container-pad py-4 flex items-center justify-between">
       <div class="font-bold text-xl">FuzzFolio</div>
@@ -15,7 +17,7 @@
         <a href="#features" class="hover:text-purple-400 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Features</a>
         <a href="#plans" class="hover:text-purple-400 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Plans</a>
         <a href="#faq" class="hover:text-purple-400 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">FAQ</a>
-        <a href="#cta" class="cta-primary cta-pill text-sm">Get Setups</a>
+        <a href="#cta" class="cta-primary cta-pill">Get setups</a>
       </div>
     </nav>
   </header>
@@ -29,7 +31,7 @@
         <a href="#features" class="focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Features</a>
         <a href="#plans" class="focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Plans</a>
         <a href="#faq" class="focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">FAQ</a>
-        <a href="#cta" class="cta-primary cta-pill focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Get Setups</a>
+        <a href="#cta" class="cta-primary cta-pill focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40">Get setups</a>
       </nav>
     </div>
   </div>

--- a/src/components/backtestingSection.js
+++ b/src/components/backtestingSection.js
@@ -4,12 +4,12 @@ export default function BacktestingSection() {
   section.className = 'section';
   section.innerHTML = `
     <div class="max-w-7xl mx-auto container-pad">
-      <div class="frame p-6 sm:p-8">
+      <div class="frame frame-glow border-gradient card-bg-gradient shadow-elevated relative corner-glow-bl p-6 sm:p-8">
         <div class="grid md:grid-cols-2 gap-8 items-center">
           <div>
             <span class="kicker">Backtesting</span>
-            <h2 class="text-2xl sm:text-3xl font-bold mt-2">Backtesting built in</h2>
-            <ul class="list-disc ml-5 mt-4 space-y-2">
+            <h2 class="text-3xl sm:text-4xl font-bold mt-2"><span class="heading-gradient">Backtesting</span> built in</h2>
+            <ul class="list-disc ml-5 mt-4 space-y-2 text-base sm:text-lg leading-relaxed text-white/80">
               <li>Configurable lookbacks</li>
               <li>Fast iteration on weights</li>
               <li>Traceable outcomes with price context</li>

--- a/src/components/ctaSection.js
+++ b/src/components/ctaSection.js
@@ -4,16 +4,16 @@ export default function CTASection() {
   section.className = 'section';
   section.innerHTML = `
     <div class="max-w-4xl mx-auto container-pad">
-      <div class="frame p-8 text-center" style="background-image:
+      <div class="frame border-gradient card-bg-gradient p-8 text-center relative corner-glow" style="background-image:
         radial-gradient(120% 90% at 0% 0%, rgba(168,85,247,.25), transparent 60%),
         radial-gradient(120% 90% at 100% 0%, rgba(236,72,153,.20), transparent 55%);">
         <span class="kicker">Join</span>
-        <h2 class="text-3xl font-bold mt-2">Ready to see clean setups?</h2>
+        <h2 class="text-3xl sm:text-4xl font-bold mt-2">Ready to see <span class="heading-gradient">clean setups</span>?</h2>
         <div class="mt-6 flex flex-col sm:flex-row gap-3 justify-center">
-          <a href="#" class="cta-primary cta-pill">Get Setups</a>
+          <a href="#" class="cta-primary cta-pill cta-animated">Get setups</a>
           <a href="#" class="cta-secondary cta-pill">Join on Telegram</a>
         </div>
-        <p class="mt-3 text-white/80 text-sm">No card. Free preview.</p>
+        <p class="mt-3 text-sm text-white/70">No credit card required</p>
       </div>
     </div>
   `;

--- a/src/components/faqAccordion.js
+++ b/src/components/faqAccordion.js
@@ -5,23 +5,23 @@ export default function FAQAccordion() {
   section.innerHTML = `
     <div class="max-w-7xl mx-auto container-pad">
       <span class="kicker">Support</span>
-      <h2 class="section-title mt-2">FAQ</h2>
+      <h2 class="section-title mt-2"><span class="heading-gradient">FAQ</span></h2>
       <div class="space-y-4 max-w-3xl mx-auto">
-        <div class="frame frame-ghost overflow-hidden">
+        <div class="frame-ghost border-gradient shadow-inset overflow-hidden">
           <button class="w-full text-left px-4 py-3 flex justify-between items-center faq-question focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40" aria-expanded="false" aria-controls="faq1">
             <span>Is this financial advice?</span>
             <span class="faq-icon text-xl">+</span>
           </button>
-          <div id="faq1" class="px-4 pb-4 hidden faq-answer" aria-hidden="true">
+          <div id="faq1" class="px-4 pb-4 hidden faq-answer text-base sm:text-lg leading-relaxed text-white/80" aria-hidden="true">
             No. FuzzFolio provides educational analysis...
           </div>
         </div>
-        <div class="frame frame-ghost overflow-hidden">
+        <div class="frame-ghost border-gradient shadow-inset overflow-hidden">
           <button class="w-full text-left px-4 py-3 flex justify-between items-center faq-question focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40" aria-expanded="false" aria-controls="faq2">
             <span>Can I cancel anytime?</span>
             <span class="faq-icon text-xl">+</span>
           </button>
-          <div id="faq2" class="px-4 pb-4 hidden faq-answer" aria-hidden="true">
+          <div id="faq2" class="px-4 pb-4 hidden faq-answer text-base sm:text-lg leading-relaxed text-white/80" aria-hidden="true">
             Yes, memberships can be cancelled anytime.
           </div>
         </div>

--- a/src/components/featureGrid.js
+++ b/src/components/featureGrid.js
@@ -4,36 +4,36 @@ export default function FeatureGrid() {
   section.className = 'section';
   section.innerHTML = `
     <div class="max-w-7xl mx-auto container-pad">
-      <div class="frame frame-glow p-6 sm:p-8">
+      <div class="frame frame-glow card-bg-gradient shadow-elevated p-6 sm:p-8">
         <span class="kicker">Platform</span>
-        <h2 class="section-title mt-2">What FuzzFolio gives you</h2>
+        <h2 class="section-title mt-2">What <span class="heading-gradient">FuzzFolio</span> gives you</h2>
         <div class="grid grid-cols-2 md:grid-cols-4 gap-4 sm:gap-6">
         <!-- Live market view -->
-        <article class="card text-center">
+        <article class="card border-gradient card-bg-gradient corner-glow shadow-elevated text-center relative motion-safe:animate-fade-up" style="animation-delay:0s">
           <div class="w-16 aspect-square skeleton rounded mx-auto mb-4" role="img" aria-label="Icon"><span class="skeleton-label">Icon</span></div>
-          <h3 class="font-semibold mb-2">Live market view</h3>
-          <p>Clean 5-minute and hourly views with core indicators.</p>
+          <h3 class="text-lg font-semibold mb-2">Live market view</h3>
+          <p class="text-base sm:text-lg leading-relaxed text-white/80">Clean 5-minute and hourly views with core indicators.</p>
         </article>
 
         <!-- Real-time alerts -->
-        <article class="card text-center">
+        <article class="card border-gradient card-bg-gradient corner-glow shadow-elevated text-center relative motion-safe:animate-fade-up" style="animation-delay:0.1s">
           <div class="w-16 aspect-square skeleton rounded mx-auto mb-4" role="img" aria-label="Icon"><span class="skeleton-label">Icon</span></div>
-          <h3 class="font-semibold mb-2">Real-time alerts</h3>
-          <p>Fuzzy logic combines indicators into one score.</p>
+          <h3 class="text-lg font-semibold mb-2">Real-time alerts</h3>
+          <p class="text-base sm:text-lg leading-relaxed text-white/80">Fuzzy logic combines indicators into one score.</p>
         </article>
 
         <!-- Historical log -->
-        <article class="card text-center">
+        <article class="card border-gradient card-bg-gradient corner-glow shadow-elevated text-center relative motion-safe:animate-fade-up" style="animation-delay:0.2s">
           <div class="w-16 aspect-square skeleton rounded mx-auto mb-4" role="img" aria-label="Icon"><span class="skeleton-label">Icon</span></div>
-          <h3 class="font-semibold mb-2">Historical log</h3>
-          <p>Review past setups and export CSVs to validate.</p>
+          <h3 class="text-lg font-semibold mb-2">Historical log</h3>
+          <p class="text-base sm:text-lg leading-relaxed text-white/80">Review past setups and export CSVs to validate.</p>
         </article>
 
         <!-- Backtesting -->
-        <article class="card text-center">
+        <article class="card border-gradient card-bg-gradient corner-glow shadow-elevated text-center relative motion-safe:animate-fade-up" style="animation-delay:0.3s">
           <div class="w-16 aspect-square skeleton rounded mx-auto mb-4" role="img" aria-label="Icon"><span class="skeleton-label">Icon</span></div>
-          <h3 class="font-semibold mb-2">Backtesting</h3>
-          <p>Validate scoring profiles quickly with transparent context.</p>
+          <h3 class="text-lg font-semibold mb-2">Backtesting</h3>
+          <p class="text-base sm:text-lg leading-relaxed text-white/80">Validate scoring profiles quickly with transparent context.</p>
         </article>
         </div>
       </div>

--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -5,12 +5,12 @@ export default function HeroSection() {
     <div class="max-w-7xl mx-auto container-pad grid lg:grid-cols-2 gap-10 items-center">
       <div>
         <span class="kicker">FuzzFolio</span>
-        <h1 class="mt-3 text-4xl md:text-6xl font-bold">
+        <h1 class="mt-3 text-5xl md:text-7xl font-bold leading-tight">
           <span class="heading-gradient">See clean setups.</span><br/>Trade on your terms.
         </h1>
-        <p class="mt-4 max-w-md">FuzzFolio helps you identify optimal trading setups...</p>
+        <p class="mt-4 max-w-md text-base sm:text-lg leading-relaxed text-white/80">FuzzFolio helps you identify optimal trading setups...</p>
         <div class="mt-8 flex gap-3">
-          <a href="#" class="cta-primary cta-pill">Get Setups</a>
+          <a href="#" class="cta-primary cta-pill cta-animated">Get setups</a>
           <a href="#" class="cta-secondary cta-pill">Join on Telegram</a>
         </div>
       </div>

--- a/src/components/pricingPlans.js
+++ b/src/components/pricingPlans.js
@@ -4,28 +4,28 @@ export default function PricingPlans() {
   section.className = 'section';
   section.innerHTML = `
     <div class="max-w-7xl mx-auto container-pad">
-      <div class="frame p-6 sm:p-8">
+      <div class="frame border-gradient card-bg-gradient shadow-inset p-6 sm:p-8">
         <span class="kicker">Pricing</span>
-        <h2 class="section-title mt-2">Plans</h2>
+        <h2 class="section-title mt-2"><span class="heading-gradient">Plans</span></h2>
         <div class="grid md:grid-cols-2 gap-8">
-          <div class="card text-center">
+          <div class="card border-gradient card-bg-gradient shadow-elevated text-center relative motion-safe:animate-fade-up" style="animation-delay:0s">
             <h3 class="text-xl font-semibold mb-4">Free — Setup Radar</h3>
-            <ul class="space-y-2 mb-4">
+            <ul class="space-y-2 mb-4 text-base sm:text-lg leading-relaxed text-white/80">
               <li>Curated watchlist opportunities</li>
               <li>Weekly recap</li>
               <li>Great for evaluating the approach</li>
             </ul>
-            <a href="#" class="cta-primary cta-pill">Join Free</a>
+            <a href="#" class="cta-primary cta-pill cta-animated">Join free</a>
           </div>
-          <div class="card text-center relative">
+          <div class="card border-gradient card-bg-gradient shadow-elevated text-center relative motion-safe:animate-fade-up" style="animation-delay:0.1s">
             <span class="absolute -top-3 right-4 text-xs bg-purple-600 text-white px-2 py-1 rounded">Best for active traders</span>
             <h3 class="text-xl font-semibold mb-4">Early Access Member — Full Feed</h3>
-            <ul class="space-y-2 mb-4">
+            <ul class="space-y-2 mb-4 text-base sm:text-lg leading-relaxed text-white/80">
               <li>Real-time scoring alerts with context</li>
               <li>Historical performance log</li>
               <li>Deep-dive analysis via PWA</li>
             </ul>
-            <a href="#" class="cta-primary cta-pill">Become a Member</a>
+            <a href="#" class="cta-primary cta-pill cta-animated">Become a member</a>
           </div>
         </div>
       </div>

--- a/src/components/showcaseSection.js
+++ b/src/components/showcaseSection.js
@@ -4,28 +4,28 @@ export default function ShowcaseSection() {
   section.innerHTML = `
     <div class="max-w-7xl mx-auto container-pad">
       <span class="kicker">Showcase</span>
-      <h2 class="section-title mt-2">FuzzFolio in action</h2>
+      <h2 class="section-title mt-2"><span class="heading-gradient">FuzzFolio</span> in action</h2>
       <div class="grid md:grid-cols-2 gap-6">
-        <div class="frame p-5 sm:p-6">
-          <h3 class="text-xl font-semibold mb-3">Clean multi-TF view</h3>
+        <div class="frame border-gradient card-bg-gradient shadow-elevated relative p-5 sm:p-6 motion-safe:animate-fade-up" style="animation-delay:0s">
+          <h3 class="text-lg font-semibold mb-3">Clean multi-TF view</h3>
           <div class="skeleton rounded-2xl aspect-[4/3]" role="img" aria-label="Multi-timeframe preview">
             <span class="skeleton-label">4:3</span>
           </div>
         </div>
-        <div class="frame p-5 sm:p-6">
-          <h3 class="text-xl font-semibold mb-3">Score timeline</h3>
+        <div class="frame border-gradient card-bg-gradient shadow-elevated relative p-5 sm:p-6 motion-safe:animate-fade-up" style="animation-delay:0.1s">
+          <h3 class="text-lg font-semibold mb-3">Score timeline</h3>
           <div class="skeleton rounded-2xl aspect-[4/3]" role="img" aria-label="Score timeline preview">
             <span class="skeleton-label">4:3</span>
           </div>
         </div>
-        <div class="frame p-5 sm:p-6">
-          <h3 class="text-xl font-semibold mb-3">Profile weights</h3>
+        <div class="frame border-gradient card-bg-gradient shadow-elevated relative p-5 sm:p-6 motion-safe:animate-fade-up" style="animation-delay:0.2s">
+          <h3 class="text-lg font-semibold mb-3">Profile weights</h3>
           <div class="skeleton rounded-2xl aspect-[4/3]" role="img" aria-label="Profile weights preview">
             <span class="skeleton-label">4:3</span>
           </div>
         </div>
-        <div class="frame p-5 sm:p-6">
-          <h3 class="text-xl font-semibold mb-3">Setup detail</h3>
+        <div class="frame border-gradient card-bg-gradient shadow-elevated relative p-5 sm:p-6 motion-safe:animate-fade-up" style="animation-delay:0.3s">
+          <h3 class="text-lg font-semibold mb-3">Setup detail</h3>
           <div class="skeleton rounded-2xl aspect-[4/3]" role="img" aria-label="Setup detail preview">
             <span class="skeleton-label">4:3</span>
           </div>

--- a/src/components/statisticBanner.js
+++ b/src/components/statisticBanner.js
@@ -3,15 +3,15 @@ export default function StatisticBanner() {
   section.className = 'section';
   section.innerHTML = `
     <div class="max-w-7xl mx-auto container-pad">
-      <div class="frame frame-glow p-6 sm:p-8 text-center">
+      <div class="frame border-gradient card-bg-gradient shadow-elevated p-6 sm:p-8 text-center">
         <span class="kicker">Community</span>
-        <p class="text-3xl font-bold mt-2">5,000+</p>
+        <p class="text-3xl font-bold mt-2"><span class="heading-gradient">5,000+</span></p>
         <p class="text-sm text-gray-300 mb-6">Traders trust FuzzFolio</p>
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 place-items-center">
-          <div class="w-28 sm:w-32 aspect-[3/1] skeleton" role="img" aria-label="Logo placeholder"><span class="skeleton-label">3:1</span></div>
-          <div class="w-28 sm:w-32 aspect-[3/1] skeleton" role="img" aria-label="Logo placeholder"><span class="skeleton-label">3:1</span></div>
-          <div class="w-28 sm:w-32 aspect-[3/1] skeleton" role="img" aria-label="Logo placeholder"><span class="skeleton-label">3:1</span></div>
-          <div class="w-28 sm:w-32 aspect-[3/1] skeleton" role="img" aria-label="Logo placeholder"><span class="skeleton-label">3:1</span></div>
+          <div class="w-28 sm:w-32 aspect-[3/1] skeleton motion-safe:animate-fade-up" style="animation-delay:0s" role="img" aria-label="Logo placeholder"><span class="skeleton-label">3:1</span></div>
+          <div class="w-28 sm:w-32 aspect-[3/1] skeleton motion-safe:animate-fade-up" style="animation-delay:0.1s" role="img" aria-label="Logo placeholder"><span class="skeleton-label">3:1</span></div>
+          <div class="w-28 sm:w-32 aspect-[3/1] skeleton motion-safe:animate-fade-up" style="animation-delay:0.2s" role="img" aria-label="Logo placeholder"><span class="skeleton-label">3:1</span></div>
+          <div class="w-28 sm:w-32 aspect-[3/1] skeleton motion-safe:animate-fade-up" style="animation-delay:0.3s" role="img" aria-label="Logo placeholder"><span class="skeleton-label">3:1</span></div>
         </div>
       </div>
     </div>

--- a/src/components/testimonials.js
+++ b/src/components/testimonials.js
@@ -4,32 +4,32 @@ export default function Testimonials() {
   section.innerHTML = `
     <div class="max-w-7xl mx-auto container-pad">
       <span class="kicker">Testimonials</span>
-      <h2 class="section-title mt-2">Traders say</h2>
+      <h2 class="section-title mt-2"><span class="heading-gradient">Traders</span> say</h2>
       <div class="grid md:grid-cols-3 gap-6">
-        <div class="frame frame-ghost p-6">
-          <p class="mb-4">"FuzzFolio helped me spot setups I used to miss."</p>
+        <div class="frame-ghost border-gradient shadow-inset p-6 motion-safe:animate-fade-up" style="animation-delay:0s">
+          <p class="mb-4 text-base sm:text-lg leading-relaxed text-white/80">"FuzzFolio helped me spot setups I used to miss."</p>
           <div class="flex items-center gap-2">
-            <div class="w-10 h-10 skeleton rounded-full grid place-items-center" role="img" aria-label="Avatar placeholder"><span class="text-xs text-white/80">A</span></div>
+            <div class="w-10 h-10 skeleton rounded-full grid place-items-center transition-transform hover:scale-105" role="img" aria-label="Avatar placeholder"><span class="text-xs text-white/80">A</span></div>
             <div>
               <span>Alex</span>
               <p class="text-xs text-gray-400">Swing Trader</p>
             </div>
           </div>
         </div>
-        <div class="frame frame-ghost p-6">
-          <p class="mb-4">"The scoring system keeps my trades disciplined."</p>
+        <div class="frame-ghost border-gradient shadow-inset p-6 motion-safe:animate-fade-up" style="animation-delay:0.1s">
+          <p class="mb-4 text-base sm:text-lg leading-relaxed text-white/80">"The scoring system keeps my trades disciplined."</p>
           <div class="flex items-center gap-2">
-            <div class="w-10 h-10 skeleton rounded-full grid place-items-center" role="img" aria-label="Avatar placeholder"><span class="text-xs text-white/80">J</span></div>
+            <div class="w-10 h-10 skeleton rounded-full grid place-items-center transition-transform hover:scale-105" role="img" aria-label="Avatar placeholder"><span class="text-xs text-white/80">J</span></div>
             <div>
               <span>Jordan</span>
               <p class="text-xs text-gray-400">Day Trader</p>
             </div>
           </div>
         </div>
-        <div class="frame frame-ghost p-6">
-          <p class="mb-4">"Backtesting is fast and easy to tweak."</p>
+        <div class="frame-ghost border-gradient shadow-inset p-6 motion-safe:animate-fade-up" style="animation-delay:0.2s">
+          <p class="mb-4 text-base sm:text-lg leading-relaxed text-white/80">"Backtesting is fast and easy to tweak."</p>
           <div class="flex items-center gap-2">
-            <div class="w-10 h-10 skeleton rounded-full grid place-items-center" role="img" aria-label="Avatar placeholder"><span class="text-xs text-white/80">T</span></div>
+            <div class="w-10 h-10 skeleton rounded-full grid place-items-center transition-transform hover:scale-105" role="img" aria-label="Avatar placeholder"><span class="text-xs text-white/80">T</span></div>
             <div>
               <span>Taylor</span>
               <p class="text-xs text-gray-400">Scalper</p>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,5 +1,11 @@
 @import "tailwindcss";
 
+@layer base {
+  body { font-family: 'Inter', sans-serif; }
+  h1, h2, h3 { font-weight: 700; letter-spacing: -0.02em; }
+  p, li { font-weight: 400; line-height: 1.5; }
+}
+
 @layer utilities {
   /* Gradient tokens for hero + accents */
   .bg-hero-gradient {
@@ -36,7 +42,7 @@
     position: absolute; inset: 0;
     background-image: linear-gradient(90deg, transparent, rgba(255,255,255,.08), transparent);
     transform: translateX(-100%);
-    animation: shimmer 1.75s infinite;
+    animation: shimmer 1.5s infinite alternate;
   }
   @keyframes shimmer { 100% { transform: translateX(100%); } }
 
@@ -66,6 +72,77 @@
     box-shadow: inset 0 0 0 1px rgba(255,255,255,.05), 0 20px 60px rgba(0,0,0,.45);
   }
 
+  /* Gradient backgrounds and outlines */
+  .card-bg-gradient {
+    background-image: radial-gradient(circle at 100% 0%, rgba(236,72,153,0.15), transparent 70%),
+                      radial-gradient(circle at 0% 100%, rgba(168,85,247,0.15), transparent 70%),
+                      linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));
+  }
+  .border-gradient { position: relative; }
+  .border-gradient::before {
+    content: '';
+    position: absolute; inset: -1px;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(130deg, #a855f7, #ec4899);
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+            mask-composite: exclude;
+  }
+  .corner-glow::after {
+    content: '';
+    position: absolute;
+    width: 60%;
+    height: 60%;
+    top: -15%;
+    right: -15%;
+    background: radial-gradient(circle, rgba(236,72,153,0.35), transparent 70%);
+    border-radius: 50%;
+    pointer-events: none;
+    z-index: -1;
+  }
+  .corner-glow-bl::after {
+    content: '';
+    position: absolute;
+    width: 60%;
+    height: 60%;
+    bottom: -15%;
+    left: -15%;
+    background: radial-gradient(circle, rgba(236,72,153,0.35), transparent 70%);
+    border-radius: 50%;
+    pointer-events: none;
+    z-index: -1;
+  }
+
+  /* Shadow variations */
+  .shadow-elevated {
+    box-shadow: 0 4px 16px rgba(0,0,0,0.6), 0 1px 3px rgba(255,255,255,0.05);
+  }
+  .shadow-inset {
+    box-shadow: inset 0 2px 6px rgba(255,255,255,0.05), inset 0 -2px 6px rgba(0,0,0,0.3);
+  }
+
+  /* Animations */
+  @keyframes gradient-border {
+    0%   { border-image-source: linear-gradient(130deg, #a855f7, #ec4899); }
+    50%  { border-image-source: linear-gradient(130deg, #ec4899, #f97316); }
+    100% { border-image-source: linear-gradient(130deg, #a855f7, #ec4899); }
+  }
+  .cta-animated {
+    border: 2px solid transparent;
+    border-radius: 0.5rem;
+    background-clip: padding-box;
+    animation: gradient-border 4s infinite;
+    border-image-slice: 1;
+  }
+  @keyframes fade-up {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  .animate-fade-up {
+    animation: fade-up 0.6s ease-out both;
+  }
+
   /* Gradient strokes for headings, subtle */
   .heading-gradient {
     background: linear-gradient(180deg, #fff, #cbd5e1 70%);
@@ -74,26 +151,34 @@
 
   /* CTA tokens */
   .cta-primary {
-    @apply px-4 py-2 rounded-lg bg-purple-600 text-white font-semibold shadow hover:shadow-lg transition focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40;
+    @apply px-4 py-2 rounded-lg bg-purple-600 text-white font-semibold shadow hover:shadow-lg transition focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40 text-sm sm:text-base;
   }
   .cta-secondary {
-    @apply px-4 py-2 rounded-lg border border-purple-600 text-purple-600 font-semibold hover:bg-purple-600 hover:text-white transition focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40;
+    @apply px-4 py-2 rounded-lg border border-purple-600 text-purple-600 font-semibold hover:bg-purple-600 hover:text-white transition focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40 text-sm sm:text-base;
+  }
+  .cta-primary:hover, .cta-secondary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 16px rgba(0,0,0,0.6), 0 0 0 2px rgba(255,255,255,0.1) inset;
+  }
+  .cta-primary:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 4px rgba(236,72,153,0.4);
   }
   .cta-pill { @apply px-4 py-2 rounded-full font-semibold; }
 }
 
 @layer components {
   .btn-primary {
-    @apply px-4 py-2 rounded-lg bg-purple-600 text-white font-semibold shadow hover:shadow-lg transition focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40;
+    @apply px-4 py-2 rounded-lg bg-purple-600 text-white font-semibold shadow hover:shadow-lg transition focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40 text-sm sm:text-base;
   }
   .btn-secondary {
-    @apply px-4 py-2 rounded-lg border border-purple-600 text-purple-600 font-semibold hover:bg-purple-600 hover:text-white transition focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40;
+    @apply px-4 py-2 rounded-lg border border-purple-600 text-purple-600 font-semibold hover:bg-purple-600 hover:text-white transition focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40 text-sm sm:text-base;
   }
   .section {
     @apply py-20;
   }
   .section-title {
-    @apply text-3xl font-bold text-center mb-8;
+    @apply text-3xl sm:text-4xl font-bold text-center mb-8;
   }
   .card {
     @apply bg-white/10 backdrop-blur rounded-2xl p-6 shadow;


### PR DESCRIPTION
## Summary
- import Inter font and adjust global typography
- add gradient backgrounds, border outlines, and entrance animations
- refresh sections with new card styling and animated CTAs

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6ffddbcc08325870ba8fd8bc31147