### PR TITLE
Fix CTA outline radius and FAQ accordion

### DIFF
--- a/src/components/faqAccordion.js
+++ b/src/components/faqAccordion.js
@@ -29,13 +29,24 @@ export default function FAQAccordion() {
     </div>
   `;
 
-  section.querySelectorAll('.faq-question').forEach(btn => {
+  const questions = section.querySelectorAll('.faq-question');
+  questions.forEach(btn => {
     btn.addEventListener('click', () => {
-      const answer = btn.nextElementSibling;
-      const open = answer.classList.toggle('hidden') === false;
-      btn.querySelector('.faq-icon')?.replaceChildren(document.createTextNode(open ? '–' : '+'));
-      btn.setAttribute('aria-expanded', String(open));
-      answer.setAttribute('aria-hidden', String(!open));
+      const expanded = btn.getAttribute('aria-expanded') === 'true';
+      questions.forEach(q => {
+        const ans = section.querySelector(`#${q.getAttribute('aria-controls')}`);
+        q.setAttribute('aria-expanded', 'false');
+        q.querySelector('.faq-icon').textContent = '+';
+        ans.classList.add('hidden');
+        ans.setAttribute('aria-hidden', 'true');
+      });
+      if (!expanded) {
+        const answer = section.querySelector(`#${btn.getAttribute('aria-controls')}`);
+        btn.setAttribute('aria-expanded', 'true');
+        btn.querySelector('.faq-icon').textContent = '–';
+        answer.classList.remove('hidden');
+        answer.setAttribute('aria-hidden', 'false');
+      }
     });
   });
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -129,8 +129,9 @@
     100% { border-image-source: linear-gradient(130deg, #a855f7, #ec4899); }
   }
   .cta-animated {
+    display: inline-block;
     border: 2px solid transparent;
-    border-radius: 0.5rem;
+    border-radius: inherit;
     background-clip: padding-box;
     animation: gradient-border 4s infinite;
     border-image-slice: 1;


### PR DESCRIPTION
## Summary
- ensure animated CTA outlines respect pill-shaped radius
- repair FAQ accordion so only one answer opens and icons update

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7066296c08325adae012715f12d41