### PR TITLE
Fix FAQ accordion overflow and infinite logo ticker

### DIFF
--- a/src/components/faqAccordion.js
+++ b/src/components/faqAccordion.js
@@ -12,7 +12,7 @@ export default function FAQAccordion() {
             <span>Is this financial advice?</span>
             <span class="faq-icon text-xl">+</span>
           </button>
-          <div id="faq1" class="faq-answer px-4 pb-4 text-base sm:text-lg leading-relaxed text-white/80 max-h-0 overflow-hidden transition-[max-height] duration-300" aria-hidden="true">
+          <div id="faq1" class="faq-answer px-4 pb-4 text-base sm:text-lg leading-relaxed text-white/80 max-h-0 overflow-hidden transition-[max-height] duration-300 hidden" aria-hidden="true">
             No. FuzzFolio provides educational analysis...
           </div>
         </div>
@@ -21,13 +21,18 @@ export default function FAQAccordion() {
             <span>Can I cancel anytime?</span>
             <span class="faq-icon text-xl">+</span>
           </button>
-          <div id="faq2" class="faq-answer px-4 pb-4 text-base sm:text-lg leading-relaxed text-white/80 max-h-0 overflow-hidden transition-[max-height] duration-300" aria-hidden="true">
+          <div id="faq2" class="faq-answer px-4 pb-4 text-base sm:text-lg leading-relaxed text-white/80 max-h-0 overflow-hidden transition-[max-height] duration-300 hidden" aria-hidden="true">
             Yes, memberships can be cancelled anytime.
           </div>
         </div>
       </div>
     </div>
   `;
+  const answers = section.querySelectorAll('.faq-answer');
+  answers.forEach(a => {
+    a.style.maxHeight = '0px';
+  });
+
   section.addEventListener('click', e => {
     const btn = e.target.closest('.faq-question');
     if (!btn) return;
@@ -40,11 +45,14 @@ export default function FAQAccordion() {
       q.querySelector('.faq-icon').textContent = '+';
       a.style.maxHeight = '0px';
       a.setAttribute('aria-hidden', 'true');
+      a.classList.add('hidden');
     });
     if (!expanded) {
       btn.setAttribute('aria-expanded', 'true');
       btn.querySelector('.faq-icon').textContent = '–';
-      answer.style.maxHeight = `${answer.scrollHeight}px`;
+      answer.classList.remove('hidden');
+      const fullHeight = answer.scrollHeight;
+      answer.style.maxHeight = `${fullHeight}px`;
       answer.setAttribute('aria-hidden', 'false');
     }
   });

--- a/src/components/statisticBanner.js
+++ b/src/components/statisticBanner.js
@@ -22,5 +22,7 @@ export default function StatisticBanner() {
       </div>
     </div>
   `;
+  const ticker = section.querySelector('.logo-ticker');
+  ticker.innerHTML += ticker.innerHTML;
   return section;
 }


### PR DESCRIPTION
## Summary
- hide FAQ answers when collapsed and reset other items when toggled
- duplicate ticker items so logo carousel loops smoothly

## Testing
- `npm run build`
```
> fuzzfolio-landing@1.0.0 build
> vite build

vite v7.1.3 building for production...
transforming...
✓ 14 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                  2.75 kB │ gzip: 0.88 kB
dist/assets/index-BOOw7Tb_.css  32.66 kB │ gzip: 5.88 kB
dist/assets/index-BJ-i6riO.js   23.04 kB │ gzip: 3.98 kB
✓ built in 505ms
```


------
https://chatgpt.com/codex/tasks/task_e_68b7113625dc8325bed5b1eb0aa090f0