### PR TITLE
Refine typography scale and spacing

### DIFF
--- a/src/components/backtestingSection.js
+++ b/src/components/backtestingSection.js
@@ -8,8 +8,8 @@ export default function BacktestingSection() {
         <div class="grid md:grid-cols-2 gap-8 items-center">
           <div>
             <span class="kicker">Backtesting</span>
-            <h2 class="text-3xl sm:text-4xl font-bold mt-2"><span class="heading-gradient">Backtesting</span> built in</h2>
-            <ul class="list-disc ml-5 mt-4 space-y-2 text-base sm:text-lg leading-relaxed text-white/80">
+            <h2 class="text-4xl md:text-5xl font-bold mt-2 mb-4"><span class="heading-gradient">Backtesting</span> built in</h2>
+            <ul class="list-disc ml-5 space-y-2 text-base sm:text-lg leading-relaxed text-white/80">
               <li>Configurable lookbacks</li>
               <li>Fast iteration on weights</li>
               <li>Traceable outcomes with price context</li>

--- a/src/components/ctaSection.js
+++ b/src/components/ctaSection.js
@@ -9,13 +9,13 @@ export default function CTASection() {
         radial-gradient(120% 90% at 100% 0%, rgba(236,72,153,.20), transparent 55%),
         linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));">
         <span class="kicker">Join</span>
-        <h2 class="text-3xl sm:text-4xl font-bold mt-2">Ready to see <span class="heading-gradient">clean setups</span>?</h2>
+        <h2 class="text-4xl md:text-5xl font-bold mt-2">Ready to see <span class="heading-gradient">clean setups</span>?</h2>
         <div class="mt-6 flex flex-col sm:flex-row gap-3 justify-center">
           <a href="#" class="cta-primary cta-pill border-gradient cta-animated">Get setups</a>
           <a href="#" class="cta-secondary cta-pill border-gradient cta-animated">Join on Telegram</a>
         </div>
-        <p class="mt-3 text-sm text-white/70">No credit card required</p>
-        <p class="mt-1 text-xs text-white/70">Updates via Telegram, no spam</p>
+        <p class="mt-3 text-sm text-white/70 max-w-sm mx-auto">No credit card required</p>
+        <p class="mt-1 text-sm text-white/70 max-w-sm mx-auto">Updates via Telegram, no spam</p>
       </div>
     </div>
   `;

--- a/src/components/faqAccordion.js
+++ b/src/components/faqAccordion.js
@@ -10,7 +10,7 @@ export default function FAQAccordion() {
         <div class="frame-ghost shadow-inset overflow-hidden">
           <button class="w-full text-left px-4 py-3 flex justify-between items-center faq-question border-b border-white/10 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40" aria-expanded="false" aria-controls="faq1">
             <span>Is this financial advice?</span>
-            <span class="faq-icon text-xl">+</span>
+            <span class="faq-icon text-2xl">+</span>
           </button>
           <div id="faq1" class="faq-answer px-4 pb-4 text-base sm:text-lg leading-relaxed text-white/80 max-h-0 overflow-hidden transition-[max-height] duration-300 hidden" aria-hidden="true">
             No. FuzzFolio provides educational analysis...
@@ -19,7 +19,7 @@ export default function FAQAccordion() {
         <div class="frame-ghost shadow-inset overflow-hidden">
           <button class="w-full text-left px-4 py-3 flex justify-between items-center faq-question border-b border-white/10 focus-visible:outline-none focus-visible:ring focus-visible:ring-purple-500/40" aria-expanded="false" aria-controls="faq2">
             <span>Can I cancel anytime?</span>
-            <span class="faq-icon text-xl">+</span>
+            <span class="faq-icon text-2xl">+</span>
           </button>
           <div id="faq2" class="faq-answer px-4 pb-4 text-base sm:text-lg leading-relaxed text-white/80 max-h-0 overflow-hidden transition-[max-height] duration-300 hidden" aria-hidden="true">
             Yes, memberships can be cancelled anytime.

--- a/src/components/featureGrid.js
+++ b/src/components/featureGrid.js
@@ -7,32 +7,32 @@ export default function FeatureGrid() {
       <div class="frame frame-glow card-bg-gradient shadow-elevated p-6 sm:p-8">
         <span class="kicker">Platform</span>
         <h2 class="section-title mt-2">What <span class="heading-gradient">FuzzFolio</span> gives you</h2>
-        <div class="grid grid-cols-2 md:grid-cols-4 gap-4 sm:gap-6">
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-x-4 gap-y-8 sm:gap-x-6 sm:gap-y-8">
         <!-- Live market view -->
-        <article class="p-5 rounded-xl bg-white/[0.04] border border-white/10 text-center relative motion-safe:animate-fade-up" style="animation-delay:0s;background-image:radial-gradient(circle at 10% 20%, rgba(236,72,153,0.08), transparent 70%);">
+        <article class="p-6 rounded-xl bg-white/[0.04] border border-white/10 text-center relative motion-safe:animate-fade-up" style="animation-delay:0s;background-image:radial-gradient(circle at 10% 20%, rgba(236,72,153,0.08), transparent 70%);">
           <div class="w-16 aspect-square skeleton rounded mx-auto mb-4" role="img" aria-label="Icon"><span class="skeleton-label">Icon</span></div>
-          <h3 class="text-lg font-semibold mb-2">Live market view</h3>
+          <h3 class="text-2xl font-semibold mb-2">Live market view</h3>
           <p class="text-base sm:text-lg leading-relaxed text-white/80">Clean 5-minute and hourly views with core indicators.</p>
         </article>
 
         <!-- Real-time alerts -->
-        <article class="p-5 rounded-xl bg-white/[0.04] border border-white/10 text-center relative motion-safe:animate-fade-up" style="animation-delay:0.1s;background-image:radial-gradient(circle at 70% 30%, rgba(168,85,247,0.08), transparent 70%);">
+        <article class="p-6 rounded-xl bg-white/[0.04] border border-white/10 text-center relative motion-safe:animate-fade-up" style="animation-delay:0.1s;background-image:radial-gradient(circle at 70% 30%, rgba(168,85,247,0.08), transparent 70%);">
           <div class="w-16 aspect-square skeleton rounded mx-auto mb-4" role="img" aria-label="Icon"><span class="skeleton-label">Icon</span></div>
-          <h3 class="text-lg font-semibold mb-2">Real-time alerts</h3>
+          <h3 class="text-2xl font-semibold mb-2">Real-time alerts</h3>
           <p class="text-base sm:text-lg leading-relaxed text-white/80">Fuzzy logic combines indicators into one score.</p>
         </article>
 
         <!-- Historical log -->
-        <article class="p-5 rounded-xl bg-white/[0.04] border border-white/10 text-center relative motion-safe:animate-fade-up" style="animation-delay:0.2s;background-image:radial-gradient(circle at 30% 80%, rgba(236,72,153,0.08), transparent 70%);">
+        <article class="p-6 rounded-xl bg-white/[0.04] border border-white/10 text-center relative motion-safe:animate-fade-up" style="animation-delay:0.2s;background-image:radial-gradient(circle at 30% 80%, rgba(236,72,153,0.08), transparent 70%);">
           <div class="w-16 aspect-square skeleton rounded mx-auto mb-4" role="img" aria-label="Icon"><span class="skeleton-label">Icon</span></div>
-          <h3 class="text-lg font-semibold mb-2">Historical log</h3>
+          <h3 class="text-2xl font-semibold mb-2">Historical log</h3>
           <p class="text-base sm:text-lg leading-relaxed text-white/80">Review past setups and export CSVs to validate.</p>
         </article>
 
         <!-- Backtesting -->
-        <article class="p-5 rounded-xl bg-white/[0.04] border border-white/10 text-center relative motion-safe:animate-fade-up" style="animation-delay:0.3s;background-image:radial-gradient(circle at 80% 70%, rgba(168,85,247,0.08), transparent 70%);">
+        <article class="p-6 rounded-xl bg-white/[0.04] border border-white/10 text-center relative motion-safe:animate-fade-up" style="animation-delay:0.3s;background-image:radial-gradient(circle at 80% 70%, rgba(168,85,247,0.08), transparent 70%);">
           <div class="w-16 aspect-square skeleton rounded mx-auto mb-4" role="img" aria-label="Icon"><span class="skeleton-label">Icon</span></div>
-          <h3 class="text-lg font-semibold mb-2">Backtesting</h3>
+          <h3 class="text-2xl font-semibold mb-2">Backtesting</h3>
           <p class="text-base sm:text-lg leading-relaxed text-white/80">Validate scoring profiles quickly with transparent context.</p>
         </article>
         </div>

--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -5,15 +5,15 @@ export default function HeroSection() {
     <div class="max-w-7xl mx-auto container-pad grid lg:grid-cols-2 gap-10 items-center">
       <div>
         <span class="kicker">FuzzFolio</span>
-        <h1 class="mt-3 text-5xl md:text-7xl font-bold leading-tight">
-          <span class="heading-gradient">See clean setups.</span><br/>Trade on your terms.
+        <h1 class="mt-3 text-6xl md:text-7xl font-extrabold leading-tight">
+          <span class="heading-gradient">See clean setups.</span><br/>Trade on <span class="heading-gradient">your terms</span>.
         </h1>
         <p class="mt-4 max-w-md text-base sm:text-lg leading-relaxed text-white/80">FuzzFolio helps you identify optimal trading setups...</p>
         <div class="mt-8 flex gap-3">
           <a href="#" class="cta-primary cta-pill border-gradient cta-animated">Get setups</a>
           <a href="#" class="cta-secondary cta-pill">Join on Telegram</a>
         </div>
-        <p class="mt-2 text-xs text-white/70">Updates via Telegram, no spam</p>
+        <p class="mt-2 text-sm text-white/70 text-center max-w-xs mx-auto">Updates via Telegram, no spam</p>
       </div>
       <div>
         <div class="grid grid-cols-3 gap-3">

--- a/src/components/howItWorks.js
+++ b/src/components/howItWorks.js
@@ -5,21 +5,21 @@ export default function HowItWorks() {
   section.innerHTML = `
     <div class="max-w-7xl mx-auto container-pad">
       <h2 class="section-title">How it works</h2>
-      <div class="relative grid md:grid-cols-3 gap-8 md:before:content-[''] md:before:absolute md:before:top-6 md:before:left-[10%] md:before:right-[10%] md:before:h-px md:before:bg-white/10">
+      <div class="relative grid md:grid-cols-3 gap-x-8 gap-y-8 md:before:content-[''] md:before:absolute md:before:top-6 md:before:left-[10%] md:before:right-[10%] md:before:h-px md:before:bg-white/10">
         <div class="card text-center relative z-10">
           <div class="w-12 h-12 skeleton rounded-full mx-auto mb-4" role="img" aria-label="Icon placeholder"><span class="skeleton-label">Icon</span></div>
-          <h3 class="font-semibold mb-2">Create a profile</h3>
-          <p>Use your preferred indicators.</p>
+          <h3 class="text-2xl font-semibold mb-2">Create a profile</h3>
+          <p class="text-base sm:text-lg leading-relaxed text-white/80">Use your preferred indicators.</p>
         </div>
         <div class="card text-center relative z-10">
           <div class="w-12 h-12 skeleton rounded-full mx-auto mb-4" role="img" aria-label="Icon placeholder"><span class="skeleton-label">Icon</span></div>
-          <h3 class="font-semibold mb-2">Backtest</h3>
-          <p>Iterate quickly on weights.</p>
+          <h3 class="text-2xl font-semibold mb-2">Backtest</h3>
+          <p class="text-base sm:text-lg leading-relaxed text-white/80">Iterate quickly on weights.</p>
         </div>
         <div class="card text-center relative z-10">
           <div class="w-12 h-12 skeleton rounded-full mx-auto mb-4" role="img" aria-label="Icon placeholder"><span class="skeleton-label">Icon</span></div>
-          <h3 class="font-semibold mb-2">Go live</h3>
-          <p>Receive real-time alerts.</p>
+          <h3 class="text-2xl font-semibold mb-2">Go live</h3>
+          <p class="text-base sm:text-lg leading-relaxed text-white/80">Receive real-time alerts.</p>
         </div>
       </div>
     </div>

--- a/src/components/personaTabs.js
+++ b/src/components/personaTabs.js
@@ -14,23 +14,23 @@ export default function PersonaTabs() {
       </div>
       <div class="persona-content max-w-3xl mx-auto">
         <div id="panel-day" data-tab="day" class="tab-panel" role="tabpanel" aria-labelledby="tab-day">
-          <p class="mb-4">Day traders can react to real-time scoring alerts and quick backtests.</p>
+          <p class="mb-4 text-base sm:text-lg leading-relaxed text-white/80">Day traders can react to real-time scoring alerts and quick backtests.</p>
           <div class="aspect-[16/9] skeleton" role="img" aria-label="Day trader dashboard preview"><span class="skeleton-label">16:9 preview</span></div>
         </div>
         <div id="panel-swing" data-tab="swing" class="tab-panel" role="tabpanel" aria-labelledby="tab-swing">
-          <p class="mb-4">Swing traders can hold positions with confidence using clear setup scores.</p>
+          <p class="mb-4 text-base sm:text-lg leading-relaxed text-white/80">Swing traders can hold positions with confidence using clear setup scores.</p>
           <div class="aspect-[16/9] skeleton" role="img" aria-label="Swing trader dashboard preview"><span class="skeleton-label">16:9 preview</span></div>
         </div>
         <div id="panel-scalper" data-tab="scalper" class="tab-panel" role="tabpanel" aria-labelledby="tab-scalper">
-          <p class="mb-4">Scalpers get fast signals to catch quick moves.</p>
+          <p class="mb-4 text-base sm:text-lg leading-relaxed text-white/80">Scalpers get fast signals to catch quick moves.</p>
           <div class="aspect-[16/9] skeleton" role="img" aria-label="Scalper dashboard preview"><span class="skeleton-label">16:9 preview</span></div>
         </div>
         <div id="panel-new" data-tab="new" class="tab-panel" role="tabpanel" aria-labelledby="tab-new">
-          <p class="mb-4">New traders learn by seeing clean setups scored in real time.</p>
+          <p class="mb-4 text-base sm:text-lg leading-relaxed text-white/80">New traders learn by seeing clean setups scored in real time.</p>
           <div class="aspect-[16/9] skeleton" role="img" aria-label="New trader dashboard preview"><span class="skeleton-label">16:9 preview</span></div>
         </div>
         <div id="panel-you" data-tab="you" class="tab-panel" role="tabpanel" aria-labelledby="tab-you">
-          <p class="mb-4">Whatever your style, FuzzFolio adapts to you.</p>
+          <p class="mb-4 text-base sm:text-lg leading-relaxed text-white/80">Whatever your style, FuzzFolio adapts to you.</p>
           <div class="aspect-[16/9] skeleton" role="img" aria-label="Personalized dashboard preview"><span class="skeleton-label">16:9 preview</span></div>
         </div>
       </div>

--- a/src/components/pricingPlans.js
+++ b/src/components/pricingPlans.js
@@ -7,25 +7,25 @@ export default function PricingPlans() {
       <div class="frame border-gradient card-bg-gradient shadow-inset p-6 sm:p-8">
         <span class="kicker">Pricing</span>
         <h2 class="section-title mt-2"><span class="heading-gradient">Plans</span></h2>
-        <div class="grid md:grid-cols-2 gap-8">
+        <div class="grid md:grid-cols-2 gap-x-8 gap-y-8">
           <div class="card border-gradient shadow-elevated text-center relative motion-safe:animate-fade-up" style="animation-delay:0s;background-image:radial-gradient(circle at 100% 0%, rgba(168,85,247,0.2), transparent 70%), radial-gradient(circle at 0% 100%, rgba(168,85,247,0.1), transparent 70%), linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));">
-            <h3 class="text-xl font-semibold mb-4">Free — Setup Radar</h3>
-            <ul class="space-y-2 mb-4 text-base sm:text-lg leading-relaxed text-white/80">
+            <h3 class="text-2xl font-semibold mb-4">Free — Setup Radar</h3>
+            <ul class="space-y-2 text-base sm:text-lg leading-relaxed text-white/80">
               <li>Curated watchlist opportunities</li>
               <li>Weekly recap</li>
               <li>Great for evaluating the approach</li>
             </ul>
-            <a href="#" class="cta-primary cta-pill border-gradient cta-animated">Join free</a>
+            <a href="#" class="cta-primary cta-pill border-gradient cta-animated inline-block mt-3">Join free</a>
           </div>
           <div class="card border-gradient shadow-elevated text-center relative motion-safe:animate-fade-up" style="animation-delay:0.1s;background-image:radial-gradient(circle at 100% 0%, rgba(236,72,153,0.25), transparent 70%), radial-gradient(circle at 0% 100%, rgba(249,115,22,0.25), transparent 70%), linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));">
-            <span class="absolute -top-5 right-4 px-3 py-1 text-xs font-semibold text-white rounded-full" style="background-image:linear-gradient(130deg, #a855f7, #ec4899);">Best for active traders</span>
-            <h3 class="text-xl font-semibold mb-4">Early Access Member — Full Feed</h3>
-            <ul class="space-y-2 mb-4 text-base sm:text-lg leading-relaxed text-white/80">
+            <span class="absolute -top-5 right-4 px-3 py-1 text-sm font-semibold text-white rounded-full" style="background-image:linear-gradient(130deg, #a855f7, #ec4899);">Best for active traders</span>
+            <h3 class="text-2xl font-semibold mb-4">Early Access Member — Full Feed</h3>
+            <ul class="space-y-2 text-base sm:text-lg leading-relaxed text-white/80">
               <li>Real-time scoring alerts with context</li>
               <li>Historical performance log</li>
               <li>Deep-dive analysis via PWA</li>
             </ul>
-            <a href="#" class="cta-primary cta-pill border-gradient cta-animated">Become a member</a>
+            <a href="#" class="cta-primary cta-pill border-gradient cta-animated inline-block mt-3">Become a member</a>
           </div>
         </div>
       </div>

--- a/src/components/showcaseSection.js
+++ b/src/components/showcaseSection.js
@@ -5,27 +5,27 @@ export default function ShowcaseSection() {
     <div class="max-w-7xl mx-auto container-pad">
       <span class="kicker">Showcase</span>
       <h2 class="section-title mt-2"><span class="heading-gradient">FuzzFolio</span> in action</h2>
-      <div class="grid md:grid-cols-2 gap-6">
-        <div class="frame border-gradient shadow-elevated relative p-5 sm:p-6 motion-safe:animate-fade-up" style="animation-delay:0s;background-image:radial-gradient(circle at 100% 0%, rgba(236,72,153,0.15), transparent 70%), radial-gradient(circle at 0% 100%, rgba(168,85,247,0.15), transparent 70%), linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));">
-          <h3 class="text-lg font-semibold mb-3">Clean multi-TF view</h3>
+      <div class="grid md:grid-cols-2 gap-x-6 gap-y-8">
+        <div class="frame border-gradient shadow-elevated relative p-6 sm:p-8 motion-safe:animate-fade-up" style="animation-delay:0s;background-image:radial-gradient(circle at 100% 0%, rgba(236,72,153,0.15), transparent 70%), radial-gradient(circle at 0% 100%, rgba(168,85,247,0.15), transparent 70%), linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));">
+          <h3 class="text-2xl font-semibold mb-3">Clean multi-TF view</h3>
           <div class="skeleton rounded-2xl aspect-[4/3]" role="img" aria-label="Multi-timeframe preview">
             <span class="skeleton-label">4:3</span>
           </div>
         </div>
-        <div class="frame border-gradient shadow-elevated relative p-5 sm:p-6 motion-safe:animate-fade-up" style="animation-delay:0.1s;background-image:radial-gradient(circle at 80% 20%, rgba(168,85,247,0.15), transparent 70%), radial-gradient(circle at 0% 100%, rgba(236,72,153,0.15), transparent 70%), linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));">
-          <h3 class="text-lg font-semibold mb-3">Score timeline</h3>
+        <div class="frame border-gradient shadow-elevated relative p-6 sm:p-8 motion-safe:animate-fade-up" style="animation-delay:0.1s;background-image:radial-gradient(circle at 80% 20%, rgba(168,85,247,0.15), transparent 70%), radial-gradient(circle at 0% 100%, rgba(236,72,153,0.15), transparent 70%), linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));">
+          <h3 class="text-2xl font-semibold mb-3">Score timeline</h3>
           <div class="skeleton rounded-2xl aspect-[4/3]" role="img" aria-label="Score timeline preview">
             <span class="skeleton-label">4:3</span>
           </div>
         </div>
-        <div class="frame border-gradient shadow-elevated relative p-5 sm:p-6 motion-safe:animate-fade-up" style="animation-delay:0.2s;background-image:radial-gradient(circle at 20% 80%, rgba(236,72,153,0.15), transparent 70%), radial-gradient(circle at 100% 0%, rgba(168,85,247,0.15), transparent 70%), linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));">
-          <h3 class="text-lg font-semibold mb-3">Profile weights</h3>
+        <div class="frame border-gradient shadow-elevated relative p-6 sm:p-8 motion-safe:animate-fade-up" style="animation-delay:0.2s;background-image:radial-gradient(circle at 20% 80%, rgba(236,72,153,0.15), transparent 70%), radial-gradient(circle at 100% 0%, rgba(168,85,247,0.15), transparent 70%), linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));">
+          <h3 class="text-2xl font-semibold mb-3">Profile weights</h3>
           <div class="skeleton rounded-2xl aspect-[4/3]" role="img" aria-label="Profile weights preview">
             <span class="skeleton-label">4:3</span>
           </div>
         </div>
-        <div class="frame border-gradient shadow-elevated relative p-5 sm:p-6 motion-safe:animate-fade-up" style="animation-delay:0.3s;background-image:radial-gradient(circle at 70% 80%, rgba(168,85,247,0.15), transparent 70%), radial-gradient(circle at 0% 0%, rgba(236,72,153,0.15), transparent 70%), linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));">
-          <h3 class="text-lg font-semibold mb-3">Setup detail</h3>
+        <div class="frame border-gradient shadow-elevated relative p-6 sm:p-8 motion-safe:animate-fade-up" style="animation-delay:0.3s;background-image:radial-gradient(circle at 70% 80%, rgba(168,85,247,0.15), transparent 70%), radial-gradient(circle at 0% 0%, rgba(236,72,153,0.15), transparent 70%), linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));">
+          <h3 class="text-2xl font-semibold mb-3">Setup detail</h3>
           <div class="skeleton rounded-2xl aspect-[4/3]" role="img" aria-label="Setup detail preview">
             <span class="skeleton-label">4:3</span>
           </div>

--- a/src/components/statisticBanner.js
+++ b/src/components/statisticBanner.js
@@ -5,7 +5,7 @@ export default function StatisticBanner() {
     <div class="max-w-7xl mx-auto container-pad">
       <div class="frame border-gradient card-bg-gradient shadow-elevated p-6 sm:p-8 text-center">
         <span class="kicker">Community</span>
-        <p class="text-3xl font-bold mt-2"><span class="heading-gradient">5,000+</span></p>
+        <p class="text-4xl md:text-5xl font-bold mt-2"><span class="heading-gradient">5,000+</span></p>
         <p class="text-sm text-gray-300 mb-6">Traders trust FuzzFolio</p>
         <div class="relative overflow-hidden edge-fade">
           <div class="logo-ticker flex gap-8 items-center w-max">

--- a/src/components/testimonials.js
+++ b/src/components/testimonials.js
@@ -10,60 +10,60 @@ export default function Testimonials() {
         <div class="min-w-[260px] flex-shrink-0 frame-ghost shadow-inset p-6 snap-start">
           <p class="mb-4 text-base sm:text-lg leading-relaxed text-white/80">"FuzzFolio helped me spot setups I used to miss."</p>
           <div class="flex items-center gap-2">
-            <div class="w-10 h-10 skeleton rounded-full grid place-items-center transition-transform hover:scale-105" role="img" aria-label="Avatar placeholder"><span class="text-xs text-white/80">A</span></div>
+            <div class="w-10 h-10 skeleton rounded-full grid place-items-center transition-transform hover:scale-105" role="img" aria-label="Avatar placeholder"><span class="text-sm text-white/80">A</span></div>
             <div>
               <span>Alex</span>
-              <p class="text-xs text-gray-400">Swing Trader</p>
+              <p class="text-sm text-gray-400">Swing Trader</p>
             </div>
           </div>
         </div>
         <div class="min-w-[260px] flex-shrink-0 frame-ghost shadow-inset p-6 snap-start">
           <p class="mb-4 text-base sm:text-lg leading-relaxed text-white/80">"The scoring system keeps my trades disciplined."</p>
           <div class="flex items-center gap-2">
-            <div class="w-10 h-10 skeleton rounded-full grid place-items-center transition-transform hover:scale-105" role="img" aria-label="Avatar placeholder"><span class="text-xs text-white/80">J</span></div>
+            <div class="w-10 h-10 skeleton rounded-full grid place-items-center transition-transform hover:scale-105" role="img" aria-label="Avatar placeholder"><span class="text-sm text-white/80">J</span></div>
             <div>
               <span>Jordan</span>
-              <p class="text-xs text-gray-400">Day Trader</p>
+              <p class="text-sm text-gray-400">Day Trader</p>
             </div>
           </div>
         </div>
         <div class="min-w-[260px] flex-shrink-0 frame-ghost shadow-inset p-6 snap-start">
           <p class="mb-4 text-base sm:text-lg leading-relaxed text-white/80">"Backtesting is fast and easy to tweak."</p>
           <div class="flex items-center gap-2">
-            <div class="w-10 h-10 skeleton rounded-full grid place-items-center transition-transform hover:scale-105" role="img" aria-label="Avatar placeholder"><span class="text-xs text-white/80">T</span></div>
+            <div class="w-10 h-10 skeleton rounded-full grid place-items-center transition-transform hover:scale-105" role="img" aria-label="Avatar placeholder"><span class="text-sm text-white/80">T</span></div>
             <div>
               <span>Taylor</span>
-              <p class="text-xs text-gray-400">Scalper</p>
+              <p class="text-sm text-gray-400">Scalper</p>
             </div>
           </div>
         </div>
         <div class="min-w-[260px] flex-shrink-0 frame-ghost shadow-inset p-6 snap-start">
           <p class="mb-4 text-base sm:text-lg leading-relaxed text-white/80">"FuzzFolio helped me spot setups I used to miss."</p>
           <div class="flex items-center gap-2">
-            <div class="w-10 h-10 skeleton rounded-full grid place-items-center transition-transform hover:scale-105" role="img" aria-label="Avatar placeholder"><span class="text-xs text-white/80">A</span></div>
+            <div class="w-10 h-10 skeleton rounded-full grid place-items-center transition-transform hover:scale-105" role="img" aria-label="Avatar placeholder"><span class="text-sm text-white/80">A</span></div>
             <div>
               <span>Alex</span>
-              <p class="text-xs text-gray-400">Swing Trader</p>
+              <p class="text-sm text-gray-400">Swing Trader</p>
             </div>
           </div>
         </div>
         <div class="min-w-[260px] flex-shrink-0 frame-ghost shadow-inset p-6 snap-start">
           <p class="mb-4 text-base sm:text-lg leading-relaxed text-white/80">"The scoring system keeps my trades disciplined."</p>
           <div class="flex items-center gap-2">
-            <div class="w-10 h-10 skeleton rounded-full grid place-items-center transition-transform hover:scale-105" role="img" aria-label="Avatar placeholder"><span class="text-xs text-white/80">J</span></div>
+            <div class="w-10 h-10 skeleton rounded-full grid place-items-center transition-transform hover:scale-105" role="img" aria-label="Avatar placeholder"><span class="text-sm text-white/80">J</span></div>
             <div>
               <span>Jordan</span>
-              <p class="text-xs text-gray-400">Day Trader</p>
+              <p class="text-sm text-gray-400">Day Trader</p>
             </div>
           </div>
         </div>
         <div class="min-w-[260px] flex-shrink-0 frame-ghost shadow-inset p-6 snap-start">
           <p class="mb-4 text-base sm:text-lg leading-relaxed text-white/80">"Backtesting is fast and easy to tweak."</p>
           <div class="flex items-center gap-2">
-            <div class="w-10 h-10 skeleton rounded-full grid place-items-center transition-transform hover:scale-105" role="img" aria-label="Avatar placeholder"><span class="text-xs text-white/80">T</span></div>
+            <div class="w-10 h-10 skeleton rounded-full grid place-items-center transition-transform hover:scale-105" role="img" aria-label="Avatar placeholder"><span class="text-sm text-white/80">T</span></div>
             <div>
               <span>Taylor</span>
-              <p class="text-xs text-gray-400">Scalper</p>
+              <p class="text-sm text-gray-400">Scalper</p>
             </div>
           </div>
         </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,7 +3,7 @@
 @layer base {
   body { font-family: 'Inter', sans-serif; }
   h1, h2, h3 { font-weight: 700; letter-spacing: -0.02em; }
-  p, li { font-weight: 400; line-height: 1.5; }
+  p, li { font-weight: 400; line-height: 1.6; }
 }
 
 @layer utilities {
@@ -133,6 +133,7 @@
   }
   .cta-animated { position: relative; z-index: 0; }
   .cta-animated::before {
+    border-radius: inherit;
     animation: gradient-border 4s linear infinite;
     background-size: 300% 300%;
   }
@@ -187,7 +188,7 @@
     @apply py-20;
   }
   .section-title {
-    @apply text-3xl sm:text-4xl font-bold text-center mb-8;
+    @apply text-4xl md:text-5xl font-bold text-center mb-4;
   }
   .card {
     @apply bg-white/10 backdrop-blur rounded-2xl p-6 shadow;


### PR DESCRIPTION
## Summary
- Simplify typography to a four-step scale with relaxed paragraph line-height and consistent section titles
- Highlight key phrases and numbers while standardising card titles, padding, and spacing across sections
- Ensure CTA outlines inherit button radii for accurate gradient animations

## Testing
- `npm run build`
```
vite v7.1.3 building for production...
transforming...
✓ 14 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                  2.75 kB │ gzip: 0.88 kB
dist/assets/index-B67KY0-M.css  33.12 kB │ gzip: 5.96 kB
dist/assets/index-BoDZ8rcF.js   23.23 kB │ gzip: 4.01 kB
✓ built in 298ms
```

------
https://chatgpt.com/codex/tasks/task_e_68b7170824c48325a757a7eb7fab9ac7