### PR TITLE
Reduce hero heading size on mobile

### DIFF
--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -5,7 +5,7 @@ export default function HeroSection() {
     <div class="max-w-7xl mx-auto container-pad grid lg:grid-cols-2 gap-10 items-center">
       <div>
         <span class="kicker">FuzzFolio</span>
-        <h1 class="mt-3 text-6xl md:text-7xl font-extrabold leading-tight">
+        <h1 class="mt-3 text-5xl sm:text-6xl md:text-7xl font-extrabold leading-tight">
           <span class="heading-gradient">See clean setups.</span><br/>Trade on <span class="heading-gradient">your terms</span>.
         </h1>
         <p class="mt-4 max-w-md text-base sm:text-lg leading-relaxed text-white/80">FuzzFolio helps you identify optimal trading setups...</p>


### PR DESCRIPTION
## Summary
- tone down hero heading size on small screens so feature tiles stay above the fold

## Testing
- `npm run build`
```
vite v7.1.3 building for production...
transforming...
✓ 14 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                  2.75 kB │ gzip: 0.88 kB
dist/assets/index-fspJUXu8.css  33.21 kB │ gzip: 5.97 kB
dist/assets/index-Ba-ASPIq.js   23.25 kB │ gzip: 4.02 kB
✓ built in 467ms
```

------
https://chatgpt.com/codex/tasks/task_e_68b71f55be988325bcad12f7ab38a031