### PR TITLE
feat: add market tile simulation to hero

### DIFF
--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -1,28 +1,33 @@
+import MarketSim from './marketSim.js';
+
 export default function HeroSection() {
   const section = document.createElement('section');
-  section.className = 'section relative bg-hero-gradient';
+  section.className = 'hero section relative bg-hero-gradient';
   section.innerHTML = `
-    <div class="max-w-7xl mx-auto container-pad grid lg:grid-cols-2 gap-10 items-center">
-      <div>
-        <span class="kicker">FuzzFolio</span>
-        <h1 class="mt-3 text-5xl sm:text-6xl md:text-7xl font-extrabold leading-tight">
-          <span class="heading-gradient">See clean setups.</span><br/>Trade on <span class="heading-gradient">your terms</span>.
-        </h1>
-        <p class="mt-4 max-w-md text-base sm:text-lg leading-relaxed text-white/80">FuzzFolio helps you identify optimal trading setups...</p>
-        <div class="mt-8 flex gap-3">
-          <a href="#" class="cta-primary cta-pill border-gradient cta-animated">Get setups</a>
-          <a href="#" class="cta-secondary cta-pill">Join on Telegram</a>
+    <div class="max-w-7xl mx-auto container-pad">
+      <div class="grid md:grid-cols-2 gap-8 items-start">
+        <div>
+          <h1 class="text-6xl md:text-7xl font-extrabold leading-tight tracking-[-0.02em]">
+            See clean setups.<br/>Trade on <span class="heading-gradient">your terms</span>.
+          </h1>
+          <p class="mt-4 text-base sm:text-lg text-white/80 leading-relaxed">
+            FuzzFolio helps you identify optimal trading setups with AI-powered analysis.
+          </p>
+          <div class="mt-6 flex items-center gap-3">
+            <a href="#" class="cta-primary cta-pill cta-animated">Get setups</a>
+            <a href="#" class="cta-secondary cta-pill cta-animated">Join on Telegram</a>
+          </div>
+          <p class="mt-3 text-sm text-white/60">Updates via Telegram, no spam</p>
         </div>
-        <p class="mt-2 text-sm text-white/70 text-center max-w-xs mx-auto">Updates via Telegram, no spam</p>
-      </div>
-      <div>
-        <div class="grid grid-cols-3 gap-3">
-          <div class="skeleton rounded-xl aspect-[9/16]" role="img" aria-label="Demo tile"><span class="skeleton-label">9:16</span></div>
-          <div class="skeleton rounded-xl aspect-[9/16]" role="img" aria-label="Demo tile"><span class="skeleton-label">9:16</span></div>
-          <div class="skeleton rounded-xl aspect-[9/16]" role="img" aria-label="Demo tile"><span class="skeleton-label">9:16</span></div>
-        </div>
+        <div id="hero-market-sim" class="md:mt-2"></div>
       </div>
     </div>
   `;
+
+  const mount = section.querySelector('#hero-market-sim');
+  mount.appendChild(
+    MarketSim({ symbols: ['AUDUSD','GBPUSD','EURUSD','USDJPY'], points: 60, intervalMs: 1000 })
+  );
+
   return section;
 }

--- a/src/components/marketSim.js
+++ b/src/components/marketSim.js
@@ -1,0 +1,144 @@
+// src/components/marketSim.js
+export default function MarketSim({ symbols = ['AUDUSD','GBPUSD','EURUSD','USDJPY'], points = 60, intervalMs = 1000 } = {}) {
+  const wrap = document.createElement('div');
+  wrap.className = 'market-grid grid grid-cols-2 gap-4 md:gap-5';
+
+  // --- State per tile
+  const tiles = symbols.map(sym => {
+    const data = Array.from({ length: points }, (_, i) => clamp01(0.5 + 0.25 * Math.sin(i / 6) + randn(0, 0.05)));
+    return { sym, data, el: null, up: 0, down: 0 };
+  });
+
+  tiles.forEach(t => { t.el = createTile(t); wrap.appendChild(t.el); updateTileVisual(t); });
+
+  const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+  let cadence = media.matches ? Math.max(intervalMs, 3000) : intervalMs;
+  const handleMotionChange = () => {
+    cadence = media.matches ? Math.max(intervalMs, 3000) : intervalMs;
+    if (timer) { clearInterval(timer); timer = setInterval(tick, cadence); }
+  };
+  media.addEventListener?.('change', handleMotionChange);
+
+  // Visibility throttle
+  let timer = null;
+  const start = () => { if (!timer) timer = setInterval(tick, cadence); };
+  const stop  = () => { if (timer) { clearInterval(timer); timer = null; } };
+  document.addEventListener('visibilitychange', () => (document.hidden ? stop() : start()));
+  start();
+
+  function tick() {
+    // Update data + scores for each tile
+    tiles.forEach(t => {
+      const last = t.data[t.data.length - 1];
+      const next = clamp01(last + randn(0, 0.07));
+      t.data.push(next); t.data.shift();
+
+      // Example scoring: up% is the normalized latest; down% is 100 - up%
+      t.up   = Math.round(next * 100);
+      t.down = 100 - t.up;
+
+      updateTileVisual(t);
+    });
+
+    // Sort (highest opportunity first)
+    const sorted = [...tiles].sort((a,b) => Math.max(b.up, b.down) - Math.max(a.up, a.down));
+    flipReorder(wrap, sorted.map(t => t.el));
+  }
+
+  return wrap;
+
+  // --- DOM helpers
+
+  function createTile(t) {
+    const card = document.createElement('article');
+    card.className = [
+      'market-tile frame border-gradient card-bg-gradient corner-glow relative p-4 md:p-5',
+      'rounded-2xl'
+    ].join(' ');
+
+    card.innerHTML = `
+      <header class="flex items-start justify-between">
+        <h3 class="text-lg md:text-xl font-semibold tracking-[-0.01em]">${t.sym}</h3>
+        <span class="inline-flex items-center text-white/60 text-sm"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M14 3h7v7h-2V6.41l-5.3 5.3-1.4-1.42 5.3-5.3H14V3zM5 5h7v2H7.41l5.3 5.3-1.42 1.4-5.3-5.3V12H5V5z"/></svg></span>
+      </header>
+
+      <div class="mt-2 flex items-center justify-between">
+        <span class="inline-flex items-center gap-2">
+          <span class="score-up text-white/80 text-base md:text-lg font-semibold"><span>0</span>%</span>
+        </span>
+        <span class="inline-flex items-center gap-2">
+          <span class="score-down text-rose-400 text-base md:text-lg font-semibold"><span>0</span>%</span>
+        </span>
+      </div>
+
+      <div class="spark mt-3 md:mt-4 rounded-xl bg-white/5 shadow-inset overflow-hidden border border-white/10">
+        <svg class="spark-svg block w-full h-[72px] md:h-[88px]" viewBox="0 0 300 88" preserveAspectRatio="none" aria-hidden="true">
+          <defs>
+            <linearGradient id="upGrad" x1="0" x2="0" y1="0" y2="1">
+              <stop offset="0%" stop-color="rgba(34,197,94,0.8)"/>
+              <stop offset="100%" stop-color="rgba(34,197,94,0.0)"/>
+            </linearGradient>
+            <linearGradient id="downGrad" x1="0" x2="0" y1="0" y2="1">
+              <stop offset="0%" stop-color="rgba(244,63,94,0.8)"/>
+              <stop offset="100%" stop-color="rgba(244,63,94,0.0)"/>
+            </linearGradient>
+          </defs>
+          <path class="area" fill="url(#upGrad)" d="M0,88 L300,88 Z"/>
+          <path class="line" fill="none" stroke="rgba(255,255,255,0.8)" stroke-width="1.5" d="M0,88 L300,88"/>
+        </svg>
+      </div>
+
+      <footer class="mt-3 text-[13px] text-white/60">about 3 hours</footer>
+    `;
+    return card;
+  }
+
+  function updateTileVisual(t) {
+    // Scores
+    t.el.querySelector('.score-up span').textContent   = t.up;
+    t.el.querySelector('.score-down span').textContent = t.down;
+
+    // Sparkline
+    const svg = t.el.querySelector('.spark-svg');
+    const { width, height } = svg.viewBox.baseVal; // 300 × 88
+    const path = pathFrom(t.data, width, height, 8);
+    const area = `${path} L ${width},${height} L 0,${height} Z`;
+
+    const areaEl = svg.querySelector('.area');
+    const lineEl = svg.querySelector('.line');
+
+    // Pick fill based on dominant side
+    const isUp = t.up >= t.down;
+    areaEl.setAttribute('fill', `url(#${isUp ? 'upGrad' : 'downGrad'})`);
+    areaEl.setAttribute('d', area);
+    lineEl.setAttribute('d', path);
+    lineEl.setAttribute('stroke', isUp ? 'rgba(34,197,94,0.9)' : 'rgba(244,63,94,0.9)');
+  }
+
+  // --- FLIP reordering animation
+  function flipReorder(container, newOrder) {
+    const first = new Map([...container.children].map(el => [el, el.getBoundingClientRect()]));
+    newOrder.forEach(el => container.appendChild(el));
+    const last = new Map([...container.children].map(el => [el, el.getBoundingClientRect()]));
+    newOrder.forEach(el => {
+      const f = first.get(el), l = last.get(el);
+      const dx = f.left - l.left, dy = f.top - l.top;
+      el.animate(
+        [{ transform: `translate(${dx}px, ${dy}px)` }, { transform: 'translate(0,0)' }],
+        { duration: 450, easing: 'cubic-bezier(.2,.7,.2,1)' }
+      );
+    });
+  }
+
+  // --- utils
+  function pathFrom(values, w, h, pad = 8) {
+    const step = (w - pad * 2) / (values.length - 1);
+    return values.map((v, i) => {
+      const x = pad + step * i;
+      const y = pad + (1 - v) * (h - pad * 2);
+      return `${i === 0 ? 'M' : 'L'}${x},${y}`;
+    }).join(' ');
+  }
+  function randn(mu = 0, sigma = 1) { return mu + sigma * (Math.random() * 2 - 1); }
+  function clamp01(x) { return Math.max(0, Math.min(1, x)); }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -175,6 +175,15 @@
     from { transform: translateX(0); }
     to { transform: translateX(-50%); }
   }
+
+  /* Market simulation tiles */
+  .market-tile { transition: box-shadow .25s ease, background-color .25s ease; }
+  .market-tile:hover { box-shadow: 0 10px 30px rgba(0,0,0,.45); }
+  .market-tile .score-up { color: rgba(255,255,255,.85); }
+  .market-tile .score-down { color: #fb7185; }
+  @media (prefers-reduced-motion: reduce) {
+    .market-tile, .market-grid * { animation: none !important; transition: none !important; }
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Summary
- replace hero demo tiles with dynamic 2x2 market simulation
- remove hero kicker pill
- add styling for market tiles with reduced-motion support

## Testing
- `npm run build`
```
vite v7.1.3 building for production...
transforming...
✓ 15 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                  2.75 kB │ gzip: 0.88 kB
dist/assets/index-DDjNk1Vx.css  34.57 kB │ gzip: 6.24 kB
dist/assets/index-ChezYnT4.js   27.17 kB │ gzip: 5.65 kB
✓ built in 321ms
```

------
https://chatgpt.com/codex/tasks/task_e_68b75e81e94883259bbc88f396a52fa2