### PR TITLE
style: show long score in green

### DIFF
--- a/src/components/marketSim.js
+++ b/src/components/marketSim.js
@@ -69,7 +69,7 @@ export default function MarketSim({ symbols = ['AUDUSD','GBPUSD','EURUSD','USDJP
 
       <div class="mt-2 flex items-center justify-between">
         <span class="inline-flex items-center gap-2">
-          <span class="score-up text-white/80 text-base md:text-lg font-semibold"><span>0</span>%</span>
+          <span class="score-up text-green-400 text-base md:text-lg font-semibold"><span>0</span>%</span>
         </span>
         <span class="inline-flex items-center gap-2">
           <span class="score-down text-rose-400 text-base md:text-lg font-semibold"><span>0</span>%</span>


### PR DESCRIPTION
## Summary
- color market sim long score green to match its sparkline

## Testing
- `npm run build`
```
$ npm run build
vite v7.1.3 building for production...
transforming...
✓ 15 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                  2.75 kB │ gzip: 0.88 kB
dist/assets/index-KwpqUY2C.css  34.66 kB │ gzip: 6.26 kB
dist/assets/index-BRqosCjW.js   27.49 kB │ gzip: 5.70 kB
✓ built in 311ms
```


------
https://chatgpt.com/codex/tasks/task_e_68b777489f088325b4d3a65b364453bc