### PR TITLE
fix: make upward market score text green

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -179,7 +179,7 @@
   /* Market simulation tiles */
   .market-tile { transition: box-shadow .25s ease, background-color .25s ease; }
   .market-tile:hover { box-shadow: 0 10px 30px rgba(0,0,0,.45); }
-  .market-tile .score-up { color: rgba(255,255,255,.85); }
+  .market-tile .score-up { color: #4ade80; }
   .market-tile .score-down { color: #fb7185; }
   @media (prefers-reduced-motion: reduce) {
     .market-tile, .market-grid * { animation: none !important; transition: none !important; }


### PR DESCRIPTION
## Summary
- color upward market scores green to match chart line

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b778a077448325b45d5f805fe014cd