### PR TITLE
Refine market tiles and FAQ styling

### DIFF
--- a/src/components/faqAccordion.js
+++ b/src/components/faqAccordion.js
@@ -1,7 +1,7 @@
 export default function FAQAccordion() {
   const section = document.createElement('section');
   section.id = 'faq';
-  section.className = 'section bg-slate-900';
+  section.className = 'section';
   section.innerHTML = `
     <div class="max-w-7xl mx-auto container-pad">
       <span class="kicker">Support</span>

--- a/src/components/marketSim.js
+++ b/src/components/marketSim.js
@@ -62,9 +62,8 @@ export default function MarketSim({ symbols = ['AUDUSD','GBPUSD','EURUSD','USDJP
     ].join(' ');
 
     card.innerHTML = `
-      <header class="flex items-start justify-between">
+      <header class="flex items-start">
         <h3 class="text-lg md:text-xl font-semibold tracking-[-0.01em]">${t.sym}</h3>
-        <span class="inline-flex items-center text-white/60 text-sm"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M14 3h7v7h-2V6.41l-5.3 5.3-1.4-1.42 5.3-5.3H14V3zM5 5h7v2H7.41l5.3 5.3-1.42 1.4-5.3-5.3V12H5V5z"/></svg></span>
       </header>
 
       <div class="mt-2 flex items-center justify-between">
@@ -77,7 +76,7 @@ export default function MarketSim({ symbols = ['AUDUSD','GBPUSD','EURUSD','USDJP
       </div>
 
       <div class="spark mt-3 md:mt-4 rounded-xl bg-white/5 shadow-inset overflow-hidden border border-white/10">
-        <svg class="spark-svg block w-full h-[72px] md:h-[88px]" viewBox="0 0 300 88" preserveAspectRatio="none" aria-hidden="true">
+        <svg class="spark-svg block w-full h-[88px] md:h-[104px]" viewBox="0 0 300 104" preserveAspectRatio="none" aria-hidden="true">
           <defs>
             <linearGradient id="upGrad" x1="0" x2="0" y1="0" y2="1">
               <stop offset="0%" stop-color="rgba(34,197,94,0.8)"/>
@@ -88,14 +87,12 @@ export default function MarketSim({ symbols = ['AUDUSD','GBPUSD','EURUSD','USDJP
               <stop offset="100%" stop-color="rgba(244,63,94,0.0)"/>
             </linearGradient>
           </defs>
-          <path class="area-up" fill="url(#upGrad)" d="M0,88 L300,88 Z"/>
-          <path class="area-down" fill="url(#downGrad)" d="M0,88 L300,88 Z"/>
-          <path class="line-up" fill="none" stroke="rgba(34,197,94,0.9)" stroke-width="1.5" d="M0,88 L300,88"/>
-          <path class="line-down" fill="none" stroke="rgba(244,63,94,0.9)" stroke-width="1.5" d="M0,88 L300,88"/>
+          <path class="area-up" fill="url(#upGrad)" d="M0,104 L300,104 Z"/>
+          <path class="area-down" fill="url(#downGrad)" d="M0,104 L300,104 Z"/>
+          <path class="line-up" fill="none" stroke="rgba(34,197,94,0.9)" stroke-width="1.5" d="M0,104 L300,104"/>
+          <path class="line-down" fill="none" stroke="rgba(244,63,94,0.9)" stroke-width="1.5" d="M0,104 L300,104"/>
         </svg>
       </div>
-
-      <footer class="mt-3 text-[13px] text-white/60">about 3 hours</footer>
     `;
     return card;
   }
@@ -107,7 +104,7 @@ export default function MarketSim({ symbols = ['AUDUSD','GBPUSD','EURUSD','USDJP
 
     // Sparkline
     const svg = t.el.querySelector('.spark-svg');
-    const { width, height } = svg.viewBox.baseVal; // 300 × 88
+    const { width, height } = svg.viewBox.baseVal; // 300 × 104
     const upSeries = t.data.map(v => Math.max(v, 0));
     const downSeries = t.data.map(v => v < 0 ? -v : 0);
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -95,10 +95,10 @@
   .corner-glow::after {
     content: '';
     position: absolute;
-    width: 60%;
-    height: 60%;
-    top: -15%;
-    right: -15%;
+    width: 200%;
+    height: 200%;
+    top: -100%;
+    right: -50%;
     background: radial-gradient(circle, rgba(236,72,153,0.35), transparent 70%);
     border-radius: 50%;
     pointer-events: none;


### PR DESCRIPTION
## Summary
- Enlarge market tile corner glow and remove header icon
- Expand sparkline and drop timestamp blurb
- Make FAQ section background transparent

## Testing
- `npm ci`
- `npm run build`
```
vite v7.1.3 building for production...
transforming...
✓ 15 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                  2.75 kB │ gzip: 0.88 kB
dist/assets/index-aiVjPIuh.css  34.64 kB │ gzip: 6.26 kB
dist/assets/index-BEWn_t-_.js   27.12 kB │ gzip: 5.54 kB
✓ built in 349ms
```


------
https://chatgpt.com/codex/tasks/task_e_68b7b5f13a6c8325bf769a14f2cb0c65